### PR TITLE
fix Parameter substitution from LocalPreferences.toml

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOboxes"
 uuid = "804b410e-d900-4b2a-9ecd-f5a06d4c1fd4"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.17.0"
+version = "0.17.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/Parameter.jl
+++ b/src/Parameter.jl
@@ -408,8 +408,15 @@ function substitutevalue(mod::Module, rawvalue::AbstractString; dontsub=("\$flux
         
         # look up in LocalPreferences.toml
         subval = m.match[2:end-1] # omit $ $
+
+        # if a Reaction is not part of a package (eg development code), use Preferences package instead to look for a key
+        if isnothing(Base.PkgId(mod).uuid)
+            @warn "substitutevalue $subval - Module $(mod) does not correspond to a loaded package, using a key from [PALEOboxes] instead"
+            mod = PALEOboxes
+        end
+
         Preferences.has_preference(mod, String(subval)) || 
-            error("substitutevalue: key $subval not found in LocalPreferences.toml")
+            error("substitutevalue: key [$(Base.PkgId(mod).name)] $subval not found in LocalPreferences.toml")
         replacestr = Preferences.load_preference(mod, String(subval)) 
        
             


### PR DESCRIPTION
A Reaction that doesn't belong to a package (eg an under-development Reaction that was #included in a script file) will use keys from PALEOboxes section of LocalPreferences.toml for Parameter substitution.