### PR TITLE
Robustness fixes for zip(...) and similar iteration

### DIFF
--- a/src/ReactionMethod.jl
+++ b/src/ReactionMethod.jl
@@ -241,7 +241,7 @@ function setup_initialvalue_vars_default(
         attrbvars = [v.linkvar for v in transfer_attribute_vars]
     end
 
-    for (rv, v, attrbv, vfield) in zip(vars, domvars, attrbvars, varfields)
+    for (rv, v, attrbv, vfield) in IteratorUtils.zipstrict(vars, domvars, attrbvars, varfields)
       
         if v === attrbv
             trsfrinfo = ""

--- a/src/VariableReaction.jl
+++ b/src/VariableReaction.jl
@@ -351,8 +351,7 @@ function create_accessors(va::VarList_components, modeldata::AbstractModelData)
         end
     end
     
-    accessors_typed = [a for a in accessors_generic] 
-    # accessors_typed = _dynamic_svector([a for a in accessors_generic])
+    accessors_typed = [a for a in accessors_generic]  # narrow Type
     return accessors_typed
 end
 

--- a/src/data/ArrayScalarData.jl
+++ b/src/data/ArrayScalarData.jl
@@ -31,7 +31,7 @@ end
 
 function check_values(
     existing_values, field_data::Type{ArrayScalarData}, data_dims::Tuple{NamedDimension, Vararg{NamedDimension}}, data_type, space::Type{<:AbstractSpace}, spatial_size::Tuple{Integer, Vararg{Integer}},
-) where {N}
+)
 
     check_data_type(existing_values, data_type)
 
@@ -43,13 +43,13 @@ function check_values(
 end
 
 
-function zero_values!(values, field_data::Type{ArrayScalarData}, data_dims::Tuple{NamedDimension, Vararg{NamedDimension}}, space::Type{ScalarSpace}, cellrange) where {N}
+function zero_values!(values, field_data::Type{ArrayScalarData}, data_dims::Tuple{NamedDimension, Vararg{NamedDimension}}, space::Type{ScalarSpace}, cellrange)
     values .= 0.0
     return nothing
 end
 
-function zero_values!(values, field_data::Type{ArrayScalarData}, data_dims::Tuple{NamedDimension, Vararg{NamedDimension}}, space::Type{CellSpace}, cellrange)  where {N}
-    data_dims_colons = ntuple(i->Colon(), length(data_dims))
+function zero_values!(values, field_data::Type{ArrayScalarData}, data_dims::Tuple{NamedDimension, Vararg{NamedDimension}}, space::Type{CellSpace}, cellrange)
+    data_dims_colons = ntuple(i->Colon(), fieldcount(typeof(data_dims)))
     @inbounds for i in cellrange.indices
         values[i, data_dims_colons...] .= 0.0
     end

--- a/src/data/AtomicScalar.jl
+++ b/src/data/AtomicScalar.jl
@@ -39,4 +39,4 @@ Fallback adds v to a[] using standard addition.
 """
 atomic_add!(as::AtomicScalar, v) = Threads.atomic_add!(as.value, v)
 
-@Base.propagate_inbounds atomic_add!(a::Array, v) = (a[] += v)
+@Base.propagate_inbounds atomic_add!(a::AbstractArray, v) = (a[] += v)

--- a/src/reactioncatalog/Fluxes.jl
+++ b/src/reactioncatalog/Fluxes.jl
@@ -364,7 +364,7 @@ function prepare_do_transfer(m::PB.ReactionMethod, (input_vardata, output_vardat
     var_inputs, var_outputs = PB.get_variables.(m.vars)
     flux_names = m.p
     nactive = 0
-    for (var_input, var_output, fluxname) in zip(var_inputs, var_outputs, flux_names)
+    for (var_input, var_output, fluxname) in PB.IteratorUtils.zipstrict(var_inputs, var_outputs, flux_names)
         if isnothing(var_output.linkvar)
             @info "    $(rpad(fluxname, 20))   $(rpad(PB.fullname(var_input.linkvar),40)) output not linked"
         else
@@ -373,10 +373,14 @@ function prepare_do_transfer(m::PB.ReactionMethod, (input_vardata, output_vardat
         end
     end
 
+    # check we have the same number of components
+    length(input_vardata) == length(output_vardata) ||
+        error("prepare_do_transfer: ReactionMethod $(PB.fullname(m)) number of input components != number of output components - check :field_data (ScalarData, IsotopeLinear etc) match")
+
     # remove unlinked Variables
     input_vardata_active = []
     output_vardata_active = []
-    for (ainput, aoutput) in zip(input_vardata, output_vardata)
+    for (ainput, aoutput) in PB.IteratorUtils.zipstrict(input_vardata, output_vardata)
         if !isnothing(aoutput)
             push!(input_vardata_active, ainput)
             push!(output_vardata_active, aoutput)
@@ -387,7 +391,7 @@ function prepare_do_transfer(m::PB.ReactionMethod, (input_vardata, output_vardat
         # figure out length of input and output arrays
         input_length = 0
         output_length = 0
-        for (ainput, aoutput) in zip(input_vardata_active, output_vardata_active)
+        for (ainput, aoutput) in PB.IteratorUtils.zipstrict(input_vardata_active, output_vardata_active)
             
             if iszero(input_length)
                 input_length = prod(size(ainput))::Int
@@ -458,7 +462,7 @@ function do_transfer(
         return nothing
     end
 
-    for (acinput, acoutput) in zip(input_vardata, output_vardata)
+    for (acinput, acoutput) in PB.IteratorUtils.zipstrict(input_vardata, output_vardata)
         _transfer(acinput, acoutput, tm_tr, cellrange)
     end
    

--- a/src/reactioncatalog/GridForcings.jl
+++ b/src/reactioncatalog/GridForcings.jl
@@ -94,10 +94,8 @@ function PB.register_methods!(rj::ReactionForceGrid)
     end
     PB.setfrozen!(rj.pars.scale_offset_var)
 
-    length(rj.pars.interp_vars.v) == length(rj.pars.interp_log.v) ||
-        error("length(interp_vars) != length(interp_log)")
     interp_vars = []
-    for (vname, vlog) in zip(rj.pars.interp_vars.v, rj.pars.interp_log.v)
+    for (vname, vlog) in PB.IteratorUtils.zipstrict(rj.pars.interp_vars.v, rj.pars.interp_log.v; errmsg="length(interp_vars) != length(interp_log)")
         @info "  adding interpolation Variable $vname log $vlog"
         push!(interp_vars, PB.VarDepScalar(vname, "",  "interpolation variable log $vlog"))
     end
@@ -231,7 +229,7 @@ function _prepare_data(rj::ReactionForceGrid, ds)
     # create variable interpolator(s) (if any)
     rj.interp_interp = []
     rj.interp_fn = []
-    for (vidx, (vname, vlog)) in enumerate(zip(rj.pars.interp_vars.v, rj.pars.interp_log.v))
+    for (vidx, (vname, vlog)) in enumerate(PB.IteratorUtils.zipstrict(rj.pars.interp_vars.v, rj.pars.interp_log.v; errmsg="length(interp_vars) != length(interp_log)"))
         if vlog
             interp_fn = log
         else

--- a/src/reactionmethods/VariableStatsMethods.jl
+++ b/src/reactionmethods/VariableStatsMethods.jl
@@ -118,7 +118,7 @@ function do_vartotals(m::AbstractReactionMethod, (vars_data, var_totals_data), c
     end
 
     length(vars_data) == length(var_totals_data) || 
-        error("do_vartotals: components length mismatch $(fullname(m)) $(get_variables_tuple(m))")
+        error("do_vartotals: components length mismatch $(fullname(m)) $(get_variables_tuple(m)) (check :field_data (ScalarData, IsotopeLinear etc) match)")
     #  if cellrange.operatorID == 0 || cellrange.operatorID in totals_method.operatorID
     for iv in eachindex(vars_data)
         calc_total(vars_data[iv], var_totals_data[iv], cellrange)

--- a/src/solverview/VariableAggregator.jl
+++ b/src/solverview/VariableAggregator.jl
@@ -29,13 +29,13 @@ with indices from corresponding `cellranges`, for `modeldata`.
 `cellranges` may contain `nothing` entries to indicate whole Domain.
 """
 function VariableAggregator(vars, cellranges, modeldata)
-    length(vars) == length(cellranges) || 
-        throw(ArgumentError("'vars' and 'cellranges' must be of same length"))
+
+    IteratorUtils.check_lengths_equal(vars, cellranges; errmsg="'vars' and 'cellranges' must be of same length")
 
     fields = []
     indices = UnitRange{Int64}[]
     nextidx = 1
-    for (v, cr) in zip(vars, cellranges)
+    for (v, cr) in IteratorUtils.zipstrict(vars, cellranges)
         f = get_field(v, modeldata)
 
         dof = dof_field(f, cr)

--- a/src/utils/IteratorUtils.jl
+++ b/src/utils/IteratorUtils.jl
@@ -1,5 +1,32 @@
 module IteratorUtils
 
+"""
+    check_lengths_equal(it1, it2)
+    check_lengths_equal(it1, it2, it3)
+    check_lengths_equal(it1, it2, it3, it4)
+    check_lengths_equal(it1, it2, it3, it4, it5)
+
+
+Error if iterables it1 ... itn do not have the same length (length(t1) == length(t2) == ...) 
+"""
+@inline check_lengths_equal(it1) = (length(it1); true)
+@inline check_lengths_equal(it1, it2; errmsg="lengths differ") = length(it1) == length(it2) || 
+    throw(ArgumentError(errmsg))
+@inline check_lengths_equal(it1, it2, it3; errmsg="lengths differ") = length(it1) == length(it2) == length(it3) || 
+    throw(ArgumentError(errmsg))
+@inline check_lengths_equal(it1, it2, it3, it4; errmsg="lengths differ") = length(it1) == length(it2) == length(it3) == length(it4) || 
+    throw(ArgumentError(errmsg))
+@inline check_lengths_equal(it1, it2, it3, it4, it5; errmsg="lengths differ") = length(it1) == length(it2) == length(it3) == length(it4) == length(it5) || 
+    throw(ArgumentError(errmsg))
+
+
+"""
+    zipstrict(iters...; errmsg="iterables lengths differ")
+
+`Base.zip` with additional check that lengths of iterables are equal.   
+"""
+@inline zipstrict(iters...; errmsg="iterables lengths differ") = (check_lengths_equal(iters...; errmsg=errmsg); zip(iters...))
+
 
 """
     named_tuple_ref(keys, eltype) 
@@ -13,8 +40,8 @@ function named_tuple_ref(keys, eltype)
 end
 
 """
-    foreach_tuple(f, t1::Tuple)
-    foreach_tuple(f, t1::Tuple, t2::Tuple)
+    foreach_tuple(f, t1::Tuple; errmsg="iterables lengths differ")
+    foreach_tuple(f, t1::Tuple, t2::Tuple; errmsg="iterables lengths differ")
 
 Call `f(t1[n])` for each element `n` of `t1::Tuple`.
 Call `f(t1[n], t2[n])` for each element `n` of `t1::Tuple`, `t2::Tuple`.
@@ -28,21 +55,24 @@ See [`foreach_longtuple`](@ref) for this.
 See https://github.com/JuliaLang/julia/issues/31869
 https://github.com/JuliaLang/julia/blob/master/base/tuple.jl (map implementation)
 """
-foreach_tuple(f, t1::Tuple{}) = ()
-foreach_tuple(f, t1::Tuple{Any, }) =
-    (@Base._inline_meta; f(t1[1]); nothing)
-foreach_tuple(f, t1::Tuple) =
-    (@Base._inline_meta; f(t1[1]); foreach_tuple(f, Base.tail(t1)); nothing)
+@inline foreach_tuple(f::F, tuples...; errmsg="iterables lengths differ") where{F} = 
+    (check_lengths_equal(tuples...; errmsg=errmsg); foreach_tuple_unchecked(f, tuples...))
 
-foreach_tuple(f, t1::Tuple{}, t2::Tuple{}) = ()
-foreach_tuple(f, t1::Tuple{Any, }, t2::Tuple{Any,}) =
+foreach_tuple_unchecked(f, t1::Tuple{}) = ()
+foreach_tuple_unchecked(f, t1::Tuple{Any, }) =
+    (@Base._inline_meta; f(t1[1]); nothing)
+foreach_tuple_unchecked(f, t1::Tuple) =
+    (@Base._inline_meta; f(t1[1]); foreach_tuple_unchecked(f, Base.tail(t1)); nothing)
+
+foreach_tuple_unchecked(f, t1::Tuple{}, t2::Tuple{}) = ()
+foreach_tuple_unchecked(f, t1::Tuple{Any, }, t2::Tuple{Any,}) =
     (@Base._inline_meta; f(t1[1], t2[1]); nothing)
-foreach_tuple(f, t1::Tuple, t2::Tuple) =
-    (@Base._inline_meta; f(t1[1], t2[1]); foreach_tuple(f, Base.tail(t1), Base.tail(t2)); nothing)
+foreach_tuple_unchecked(f, t1::Tuple, t2::Tuple) =
+    (@Base._inline_meta; f(t1[1], t2[1]); foreach_tuple_unchecked(f, Base.tail(t1), Base.tail(t2)); nothing)
 
 """
-    foreach_longtuple(f, t1::Tuple, t2, ... tm)
-    foreach_longtuple_p(f, t1::Tuple, t2, ... tm, p)
+    foreach_longtuple(f, t1::Tuple, t2, ... tm; errmsg="iterables lengths differ")
+    foreach_longtuple_p(f, t1::Tuple, t2, ... tm, p; errmsg="iterables lengths differ")
 
 Call `f(t1[n], t2[n], ... tm[n])` or `f(t1[n], t2[n], ... tm[n], p)` for each element
 `n` of `t1::Tuple`, `t2`, ... `tm`.
@@ -52,7 +82,10 @@ Uses `@generated` to generate unrolled code for speed and type stability without
 
 See https://discourse.julialang.org/t/manually-unroll-operations-with-objects-of-tuple/11604
 """
-@generated function foreach_longtuple(f, t1::Tuple)
+@inline foreach_longtuple(f::F, tuples...; errmsg="iterables lengths differ") where{F} = 
+    (check_lengths_equal(tuples...; errmsg=errmsg); foreach_longtuple_unchecked(f, tuples...))
+
+@generated function foreach_longtuple_unchecked(f, t1::Tuple)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j]); end)
@@ -62,7 +95,7 @@ See https://discourse.julialang.org/t/manually-unroll-operations-with-objects-of
     return ex
 end
 
-@generated function foreach_longtuple(f, t1::Tuple, t2)
+@generated function foreach_longtuple_unchecked(f, t1::Tuple, t2)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j]); end)
@@ -72,7 +105,7 @@ end
     return ex
 end
 
-@generated function foreach_longtuple(f, t1::Tuple, t2, t3)
+@generated function foreach_longtuple_unchecked(f, t1::Tuple, t2, t3)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j], t3[$j]); end)
@@ -82,7 +115,7 @@ end
     return ex
 end
 
-@generated function foreach_longtuple(f, t1::Tuple, t2, t3, t4)
+@generated function foreach_longtuple_unchecked(f, t1::Tuple, t2, t3, t4)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j], t3[$j], t4[$j]); end)
@@ -92,7 +125,7 @@ end
     return ex
 end
 
-@generated function foreach_longtuple(f, t1::Tuple, t2, t3, t4, t5)
+@generated function foreach_longtuple_unchecked(f, t1::Tuple, t2, t3, t4, t5)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j], t3[$j], t4[$j], t5[$j]); end)
@@ -102,7 +135,9 @@ end
     return ex
 end
 
-@generated function foreach_longtuple_p(f, t1::Tuple, p)
+@inline foreach_longtuple_p(f::F, t1, p; errmsg="iterables lengths differ") where{F} =
+    foreach_longtuple_unchecked_p(f, t1, p)
+@generated function foreach_longtuple_unchecked_p(f, t1::Tuple, p)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], p); end)
@@ -112,7 +147,9 @@ end
     return ex
 end
 
-@generated function foreach_longtuple_p(f, t1::Tuple, t2, p)
+@inline foreach_longtuple_p(f::F, t1, t2, p; errmsg="iterables lengths differ") where{F} =
+    foreach_longtuple_unchecked_p(f, t1, t2, p)
+@generated function foreach_longtuple_unchecked_p(f, t1::Tuple, t2, p)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j], p); end)
@@ -122,7 +159,9 @@ end
     return ex
 end
 
-@generated function foreach_longtuple_p(f, t1::Tuple, t2, t3, p)
+@inline foreach_longtuple_p(f::F, t1, t2, t3, p; errmsg="iterables lengths differ") where{F} =
+    foreach_longtuple_unchecked_p(f, t1, t2, t3, p)
+@generated function foreach_longtuple_unchecked_p(f, t1::Tuple, t2, t3, p)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j], t3[$j], p); end)
@@ -132,7 +171,9 @@ end
     return ex
 end
 
-@generated function foreach_longtuple_p(f, t1::Tuple, t2, t3, t4, p)
+@inline foreach_longtuple_p(f::F, t1, t2, t3, t4, p; errmsg="iterables lengths differ") where{F} =
+    foreach_longtuple_unchecked_p(f, t1, t2, t3, t4, p)
+@generated function foreach_longtuple_unchecked_p(f, t1::Tuple, t2, t3, t4, p)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j], t3[$j], t4[$j], p); end)
@@ -142,7 +183,9 @@ end
     return ex
 end
 
-@generated function foreach_longtuple_p(f, t1::Tuple, t2, t3, t4, t5, p)
+@inline foreach_longtuple_p(f::F, t1, t2, t3, t4, t5, p; errmsg="iterables lengths differ") where{F} =
+    foreach_longtuple_unchecked_p(f, t1, t2, t3, t4, t5, p)
+@generated function foreach_longtuple_unchecked_p(f, t1::Tuple, t2, t3, t4, t5, p)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; f(t1[$j], t2[$j], t3[$j], t4[$j], t5[$j], p); end)
@@ -153,7 +196,7 @@ end
 end
 
 """
-    reduce_longtuple(f, rinit, t1::Tuple, t2, ... tm) -> r
+    reduce_longtuple(f, rinit, t1::Tuple, t2, ... tm; errmsg="iterables lengths differ") -> r
 
 Call `r += f(r, t1[n], t2[n], ... tm[n])`  for each element
 `n` of `t1::Tuple`, `t2`, ... `tm`. Initial value of `r = rinit`
@@ -163,8 +206,10 @@ Uses `@generated` to generate unrolled code for speed and type stability without
 
 See https://discourse.julialang.org/t/manually-unroll-operations-with-objects-of-tuple/11604
 """
+@inline reduce_longtuple(f::F, rinit, tuples...; errmsg="iterables lengths differ") where{F} = 
+    (check_lengths_equal(tuples...; errmsg=errmsg); reduce_longtuple_unchecked(f, rinit, tuples...))
 
-@generated function reduce_longtuple(f, rinit, t1::Tuple)
+@generated function reduce_longtuple_unchecked(f, rinit, t1::Tuple)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; rinit = f(rinit, t1[$j]); end)
@@ -174,7 +219,7 @@ See https://discourse.julialang.org/t/manually-unroll-operations-with-objects-of
     return ex
 end
 
-@generated function reduce_longtuple(f, rinit, t1::Tuple, t2)
+@generated function reduce_longtuple_unchecked(f, rinit, t1::Tuple, t2)
     ex = quote ; end  # empty expression
     for j=1:fieldcount(t1)
         push!(ex.args, quote; rinit = f(rinit, t1[$j], t2[$j]); end)

--- a/src/utils/TestUtils.jl
+++ b/src/utils/TestUtils.jl
@@ -46,7 +46,7 @@ function bench_method(dispatchlist, domainname="", reactionname="", methodname="
 
     # fns, methods, vardatas, crs = dispatchlist
     # iterate through dispatchlist, if names match then benchmark method else just call method
-    for (fn, method, vardata, cr) in zip(
+    for (fn, method, vardata, cr) in PB.IteratorUtils.zipstrict(
                                         dispatchlist.methodfns, 
                                         dispatchlist.methods,
                                         dispatchlist.vardatas, 


### PR DESCRIPTION
Julia zip(iters...) doesn't check that the supplied iterators have the same length.
This means that PALEO code that eg iterates over lists of Variables is fragile if a coding error somehow creates lists of different lengths.

To workaround this, add
IteratorUtils.check_lengths_equal(iters...)
IteratorUtils.zipstrict(iters...)

and also update IteratorUtils.foreach_longtuple and similar to check lengths