### PR TITLE
Change defaults for :field_data to UndefinedData for VarDep, VarContrib

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -187,7 +187,7 @@ function allocate_variables!(
     vars = get_variables(domain, hostdep=hostdep)
    
     @info "Domain $(rpad(domain.name,20)) data dimensions $(rpad(domain.data_dims,20)) "*
-        "allocating $(rpad(length(vars),4)) internal variables (hostdep=$(hostdep))"  
+        "allocating $(rpad(length(vars),4)) variables (hostdep=$(hostdep))"  
  
     for v in vars
         data_dims = Tuple(
@@ -211,6 +211,16 @@ function allocate_variables!(
         field_data = get_attribute(v, :field_data)
         space = get_attribute(v, :space)
 
+        if field_data == UndefinedData
+            if host_dependent(v)
+                field_data = ScalarData
+                set_attribute!(v, :field_data, ScalarData)
+                field_data = get_attribute(v, :field_data)
+                @info "    set :field_data=$field_data for host-dependent Variable $(fullname(v))"
+            else
+                error("allocate_variables! :field_data=UndefinedData for Variable $(fullname(v))")
+            end
+        end
         v_field = allocate_field(
             field_data, data_dims, mdeltype, space, domain.grid,
             thread_safe=thread_safe, allocatenans=modeldata.allocatenans

--- a/src/VariableAttributes.jl
+++ b/src/VariableAttributes.jl
@@ -126,7 +126,7 @@ List of standard Variable attributes.
 const StandardAttributes = [
     #                                   name                    default_value    required    units       description    
 
-    Attribute{Type, AbstractData}(        :field_data,           ScalarData,      true,       "",         "AbstractData type Variable contains")    
+    Attribute{Type, AbstractData}(        :field_data,           UndefinedData,   true,       "",         "AbstractData type Variable contains")    
     Attribute{Tuple{Vararg{String}}, Tuple{Vararg{String}}}(
                                           :data_dims,            (),              true,       "",         "Variable data dimensions, or empty for a scalar")
     Attribute{Type, AbstractSpace}(       :space,                CellSpace,       true,       "",           "function space Variable is defined on")

--- a/src/VariableReaction.jl
+++ b/src/VariableReaction.jl
@@ -39,10 +39,10 @@ end
 
 get_var_type(var::VariableReaction{T}) where T = T
 
-VarPropT        = VariableReaction{VT_ReactProperty}
-VarDepT         = VariableReaction{VT_ReactDependency}
-VarTargetT      = VariableReaction{VT_ReactTarget}
-VarContribT     = VariableReaction{VT_ReactContributor}
+const VarPropT        = VariableReaction{VT_ReactProperty}
+const VarDepT         = VariableReaction{VT_ReactDependency}
+const VarTargetT      = VariableReaction{VT_ReactTarget}
+const VarContribT     = VariableReaction{VT_ReactContributor}
 
 """
     get_domvar_attribute(var::VariableReaction, name::Symbol, missing_value=missing) -> value
@@ -167,8 +167,8 @@ end
 
 VarPropScalar(localname, units, description; attributes::Tuple=(), kwargs...) =
     VarProp(localname, units, description; attributes=(:space=>ScalarSpace, attributes...), kwargs...)
-VarProp(localname, units, description; kwargs... ) = 
-    CreateVariableReaction(VT_ReactProperty, localname, units, description; kwargs...)
+VarProp(localname, units, description; attributes::Tuple=(), kwargs... ) = 
+    CreateVariableReaction(VT_ReactProperty, localname, units, description; attributes=(:field_data=>ScalarData, attributes...), kwargs...)
             
 VarPropScalarStateIndep(localname, units, description; attributes::Tuple=(), kwargs... ) =
     VarPropScalar(localname, units, description; attributes=(attributes..., :datatype=>Float64), kwargs...)
@@ -205,8 +205,8 @@ end
 
 VarTargetScalar(localname, units, description; attributes::Tuple=(), kwargs... ) = 
     VarTarget(localname, units, description; attributes=(:space=>ScalarSpace, attributes...), kwargs...)
-VarTarget(localname, units, description; kwargs... ) = 
-    CreateVariableReaction(VT_ReactTarget, localname, units, description; kwargs...)
+VarTarget(localname, units, description; attributes::Tuple=(), kwargs... ) = 
+    CreateVariableReaction(VT_ReactTarget, localname, units, description; attributes=(:field_data=>ScalarData, attributes...), kwargs...)
         
 VarContribScalar(localname, units, description; attributes::Tuple=(), kwargs... ) = 
     VarContrib(localname, units, description; attributes=(:space=>ScalarSpace, attributes...), kwargs...)
@@ -223,30 +223,30 @@ VarContrib(v::VarTargetT) = VarContribT(
 )
 
 VarStateExplicitScalar(localname, units, description; attributes::Tuple=(), kwargs...) =
-    VarDepScalar(localname, units, description; attributes=(attributes..., :vfunction=>VF_StateExplicit), kwargs...)
+    VarDepScalar(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_StateExplicit), kwargs...)
 VarStateExplicit(localname, units, description; attributes::Tuple=(), kwargs... ) = 
-    VarDep(localname, units, description; attributes=(attributes..., :vfunction=>VF_StateExplicit), kwargs...)
+    VarDep(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_StateExplicit), kwargs...)
     
 VarTotalScalar(localname, units, description; attributes::Tuple=(), kwargs...) =
     VarContribScalar(localname, units, description;
-        components, attributes=(attributes..., :vfunction=>VF_Total), kwargs...)
+        components, attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_Total), kwargs...)
 VarTotal(localname, units, description; attributes::Tuple=(), kwargs... ) = 
-        VarContrib(localname, units, description; attributes=(attributes..., :vfunction=>VF_Total), kwargs...)
+        VarContrib(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_Total), kwargs...)
          
 VarDerivScalar(localname, units, description; attributes::Tuple=(), kwargs... ) =
-    VarContribScalar(localname, units, description; attributes=(attributes..., :vfunction=>VF_Deriv), kwargs...)
+    VarContribScalar(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_Deriv), kwargs...)
 VarDeriv(localname, units, description; attributes::Tuple=(), kwargs... ) = 
-    VarContrib(localname, units, description; attributes=(attributes..., :vfunction=>VF_Deriv),  kwargs...)
+    VarContrib(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_Deriv),  kwargs...)
          
 VarConstraintScalar(localname, units, description; attributes::Tuple=(), kwargs... ) =
-    VarContribScalar(localname, units, description; attributes=(attributes..., :vfunction=>VF_Constraint), kwargs...)
+    VarContribScalar(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_Constraint), kwargs...)
 VarConstraint(localname, units, description; attributes::Tuple=(), kwargs... ) = 
-        VarContrib(localname, units, description; attributes=(attributes..., :vfunction=>VF_Constraint), kwargs...)
+        VarContrib(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_Constraint), kwargs...)
          
 VarStateScalar(localname, units, description; attributes::Tuple=(), kwargs...) =
-    VarDepScalar(localname, units, description; attributes=(attributes..., :vfunction=>VF_State), kwargs...)
+    VarDepScalar(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_State), kwargs...)
 VarState(localname, units, description; attributes::Tuple=(), kwargs... ) = 
-    VarDep(localname, units, description; attributes=(attributes..., :vfunction=>VF_State), kwargs...)
+    VarDep(localname, units, description; attributes=(:field_data=>ScalarData, attributes..., :vfunction=>VF_State), kwargs...)
    
 # TODO: define a VarInit Type. Currently (ab)using VarDep   
 VarInit(v::Union{VarPropT, VarTargetT, VarContribT}) = VarDepT(        

--- a/src/reactioncatalog/VariableStats.jl
+++ b/src/reactioncatalog/VariableStats.jl
@@ -69,9 +69,9 @@ function PB.register_methods!(rj::ReactionSum)
             PB.parse_variablereaction_namestr(varname)
         localname = PB.combine_link_name(linkreq_domain, "", linkreq_name, sep="_")
          # mark all vars_to_add as optional to help diagnose config errors
-         # NB: :field_data=>PB.UndefinedData  to allow Variable to link to any data type (this is checked later)
+         # default :field_data=>PB.UndefinedData  to allow Variable to link to any data type (this is checked later)
         push!(vars_to_add, 
-            PB.VarDep(localname, "", "", link_namestr="("*varname*")", attributes=(:field_data=>PB.UndefinedData,))
+            PB.VarDep(localname, "", "", link_namestr="("*varname*")")
         )
     end
 


### PR DESCRIPTION
Increases robustness as defaults now will link to Variables with any :field_data type

As before VarProp, VarTarget default to ScalarData, as do state etc Variables (:vfunction != VF_Undefined)

If it is intended to only link to a total (ignoring isotopes), then this requires explicitly setting :field_data=ScalarData