### PR TITLE
Add convert method for IsotopeLinear

### DIFF
--- a/src/data/IsotopeData.jl
+++ b/src/data/IsotopeData.jl
@@ -182,6 +182,9 @@ Base.:*(a::IsotopeLinear,  b::Real)             = IsotopeLinear(a.v*b, a.v_molde
 Base.:*(a::Real, b::IsotopeLinear)              = IsotopeLinear(a*b.v, a*b.v_moldelta)
 Base.:/(a::IsotopeLinear,  b::Real)             = IsotopeLinear(a.v/b, a.v_moldelta/b)
 
+# convert methods for cases (eg from Float64 to an AD type) where scalar components v, v_moldelta can be converted
+IsotopeLinear{T1, T2}(x::IsotopeLinear) where {T1, T2} = IsotopeLinear{T1, T2}(x.v, x.v_moldelta)
+Base.convert(::Type{IsotopeLinear{T1, T2}}, x::IsotopeLinear) where {T1, T2} = IsotopeLinear{T1, T2}(x)
 
 """
     IsotopeTypes::Tuple


### PR DESCRIPTION
This is needed for StructArrays v0.6.8 https://github.com/JuliaArrays/StructArrays.jl/releases/tag/v0.6.8
See
https://github.com/JuliaArrays/StructArrays.jl/issues/131
https://github.com/JuliaArrays/StructArrays.jl/issues/216

It's not clear to me whether the behaviour of StructArrays.jl is now correct (so this is a PALEOboxes.jl fix that
used to not matter) or whether this is a workaround for a newly introduced StructArrays.jl issue