### PR TITLE
Change SLEEF default to disabled

### DIFF
--- a/src/utils/SIMDutils.jl
+++ b/src/utils/SIMDutils.jl
@@ -236,8 +236,8 @@ const FP32P8_d = NTuple{8,Core.VecElement{Float32}}
 const FP32P4_d = NTuple{4,Core.VecElement{Float32}}
 
 if !@Preferences.has_preference("USE_SLEEF")
-    @info "$(@__MODULE__) defining USE_SLEEF = true in LocalPreferences.toml"
-    @Preferences.set_preferences!("USE_SLEEF"=>true)
+    @info "$(@__MODULE__) defining USE_SLEEF = false in LocalPreferences.toml"
+    @Preferences.set_preferences!("USE_SLEEF"=>false)
 end
 
 const USE_SLEEF = @Preferences.load_preference("USE_SLEEF", false)
@@ -276,8 +276,8 @@ const USE_SLEEF = @Preferences.load_preference("USE_SLEEF", false)
     sleeflog10(v::FP32P4_d)   = ccall((:Sleef_log10f4_u10, SLEEF_jll.libsleef), FP32P4_d, (FP32P4_d,), v)
     Base.log10(v::FP32P4)     = SIMD.Vec(sleeflog10(v.data))
 else
-    @info "$(@__MODULE__) No Sleef library, using defaults (probably slow scalar fallbacks) for SIMD log, exp, log10 functions"*
-        " - to enable Sleef, set USE_SLEEF = true in LocalPreferences.toml and restart your Julia session"
+    @info "$(@__MODULE__) Using defaults (probably slow scalar fallbacks) for SIMD log, exp, log10 functions"*
+        " - to enable Sleef library, set USE_SLEEF = true in LocalPreferences.toml and restart your Julia session"
 end
 
 end # module


### PR DESCRIPTION
This makes using SLEEF opt-in, by defining USE_SLEEF = true in LocalPreferences.toml

Reason is that any issues with SLEEF (eg lack of hardware support)
can result in Julia exiting with no error message, hence are hard to spot.