### PR TITLE
Fix setup of constant (non-state) Variables

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOboxes"
 uuid = "804b410e-d900-4b2a-9ecd-f5a06d4c1fd4"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.19.1"
+version = "0.19.2"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/VariableReaction.jl
+++ b/src/VariableReaction.jl
@@ -361,7 +361,7 @@ function create_accessors(va::VarList_components, modeldata::AbstractModelData)
             if va.allow_unlinked
                 append!(accessors_generic, fill(nothing, num_components(v)))
             else
-                error("create_accessors(::VarList_components, ) - unlinked variable $(v.reaction.name).$(v.localname) $v")
+                error("create_accessors(::VarList_components, ) - unlinked variable $(fullname(v)) $v")
             end
         else
             append!(accessors_generic, a)

--- a/src/reactioncatalog/Reservoirs.jl
+++ b/src/reactioncatalog/Reservoirs.jl
@@ -88,7 +88,12 @@ function PB.register_methods!(rj::ReactionReservoirScalar)
 
     if rj.pars.const.v
         R            = PB.VarPropScalar(      "R", "mol", "scalar constant reservoir", attributes=(:field_data =>rj.pars.field_data.v,))
-        PB.add_method_setup_initialvalue_vars_default!(rj, [R], filterfn = v->true, setup_callback=setup_callback)  # force setup even though R is not a state Variable
+        PB.add_method_setup_initialvalue_vars_default!(
+            rj, [R], 
+            filterfn = v->true, # force setup even though R is not a state Variable
+            force_initial_norm_value=true, # setup :norm_value, :initial_value to get norm_value callback, even though R is not a state Variable
+            setup_callback=setup_callback
+        )  
         # no _sms variable
     else        
         R        = PB.VarStateExplicitScalar("R", "mol", "scalar reservoir", attributes=(:field_data =>rj.pars.field_data.v,))


### PR DESCRIPTION
Fixes for 'add_method_setup_initialvalue_vars_default!',
  'setup_initialvalue_vars_default' for cases where Variable is not a
   state Variable:
- now looks at Variable :vfunction attribute
- can be overriden by force_initial_norm_value optional argument,
  when a non-state Variable still needs :norm_value, :initial_value setup