### PR TITLE
Simplify Reaction method dispatch, update doc

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOboxes"
 uuid = "804b410e-d900-4b2a-9ecd-f5a06d4c1fd4"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.19.2"
+version = "0.20.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/docs/src/Reaction API.md
+++ b/docs/src/Reaction API.md
@@ -5,7 +5,7 @@ CurrentModule = PALEOboxes
 API calls used by [`AbstractReaction`](@ref) implementations.
 
 Implementations should create a subclass of [`AbstractReaction`](@ref) containing a [`ReactionBase`](@ref) and
-[`Parameter`](@ref)s, register a reaction factory, and implement callbacks to define [`VariableReaction`](@ref)s and [`ReactionMethod`](@ref)s.
+[`Parameter`](@ref)s, optionally provide a [`create_reaction`](@ref), and implement callbacks to define [`VariableReaction`](@ref)s and register [`ReactionMethod`](@ref)s.
 
 ## Reaction struct
 ```@meta
@@ -27,7 +27,13 @@ add_par
 setvalue!
 ```
 
-## Registering with PALEOboxes framework
+## Registering Reactions with the PALEOboxes framework
+
+All subtypes of [`AbstractReaction`](@ref) that are present in loaded modules are
+available to the PALEO framework.  Available Reactions can be listed with [`find_reaction`](@ref)
+and [`find_all_reactions`](@ref).  The default [`create_reaction`](@ref) is called to create Reactions
+when the model is created (this method can be overridden if needed).
+
 ```@docs
 create_reaction(ReactionType::Type{<:AbstractReaction}, base::ReactionBase)
 
@@ -35,18 +41,25 @@ find_reaction
 find_all_reactions
 ```
 
-## Optional initialisation callbacks to define Domain Grids and array sizes
-One Reaction per domain may implement [`set_model_geometry`](@ref) to create and attach
-a grid, and [`set_data_dimension!`](@ref).
+## Defining Domain Grids and array sizes
 ```@docs
 set_model_geometry
 set_data_dimension!
 ```
 
-## Initialisation callbacks
+## Registering Reaction methods
+All Reactions should implement [`register_methods!`](@ref), and may optionally implement [`register_dynamic_methods!`](@ref).
 ```@docs
 register_methods!
 register_dynamic_methods!
+```
+
+## Implementing ReactionMethods
+```@docs
+ReactionMethod
+add_method_setup!
+add_method_initialize!
+add_method_do!
 ```
 
 ### Defining [`VariableReaction`](@ref)s
@@ -68,14 +81,6 @@ VarList_nothing
 VarList_tuple_nothing
 ```
 
-### Registering ReactionMethods
-```@docs
-ReactionMethod
-add_method_setup!
-add_method_initialize!
-add_method_do!
-```
-
 ## Predefined ReactionMethods
 
 ### Setup and initialization of Variables
@@ -95,10 +100,8 @@ RateStoich
 create_ratestoich_method
 ```
 
-## Implementing Reaction method functions
-Method functions should iterate over cells using the supplied `cellrange.indices`.
 
-### Optimising loops over cells using explicit SIMD instructions
+## Optimising loops over cells using explicit SIMD instructions
 Reactions with simple loops over `cellindices` that implement time-consuming per-cell calculations 
 may be optimised by using explicit SIMD instructions.
 ```@docs

--- a/src/CellRange.jl
+++ b/src/CellRange.jl
@@ -1,12 +1,28 @@
 
 
 """
-    CellRange
+    AbstractCellRange
+
+Defines a range of cells within a [`Domain`](@ref).
+
+# Fields
+All implementations should define:
+- `domain::Domain`: the [`Domain`](@ref) covered by this cellrange.
+- `operatorID::Int`: If `operatorID==0`, call all `Reaction`s, otherwise
+  only call those with matching `operatorID` (this enables operator splitting).
+- `indices`: an iterable list of cell indices.
+
+And then may provide subtype-specific fields defining additional ranges of cells.
+"""
+AbstractCellRange
+
+""" 
+    CellRange <: AbstractCellRange
 
 Defines a range of cells in a specified [`Domain`](@ref) as a linear list.
 
-If `operatorID==0`, call all `Reaction`s, otherwise
-only call those with matching `operatorID` (this enables operator splitting).
+# Fields
+$(FIELDS)
 """
 Base.@kwdef mutable struct CellRange{T} <: AbstractCellRange
     domain::Domain
@@ -28,16 +44,17 @@ end
 
 
 """
-    CellRangeColumns
+    CellRangeColumns <: AbstractCellRange
 
-Defines a range of cells in a specified [`Domain`](@ref), organised by columns.
-If `operatorID==0`, call all `Reaction`s, otherwise
-only call those with matching `operatorID` (this enables operator splitting).
+Defines a range of cells in a specified [`Domain`](@ref), organised by `columns`.
+
+# Fields
+$(FIELDS)
 """
 Base.@kwdef mutable struct CellRangeColumns{T1, T2} <: AbstractCellRange
     domain::Domain
     operatorID::Int     = 0
-    "iterator through cells in arbitrary order"
+    "iterator through all cells in arbitrary order"
     indices::T1
     "iterator through columns: columns[n] returns a Pair icol=>cells where cells are ordered top to bottom"
     columns::T2

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -3,6 +3,12 @@ import Infiltrator
     Domain
     
 A model region containing Variables and Reactions that act on them.
+
+Domain spatial size is defined by `grid`, which may be `nothing` to define a scalar Domain,
+or an [`AbstractMesh`](@ref) to define a spatially-resolved Domain with multiple cells.
+
+Named `data_dims` may be set by [`set_data_dimension!`](@ref) to allow Variables with additional non-spatial dimensions, eg
+to represent quantities on a wavelength grid.
 """
 Base.@kwdef mutable struct Domain <: AbstractDomain
     name::String
@@ -18,9 +24,9 @@ end
 """
     set_data_dimension!(domain::Domain, dim::NamedDimension; allow_exists=false)
 
-Define a Domain data dimension.
+Define a Domain data dimension as a [`NamedDimension`](@ref)
 
-Variable data dimensions are then defined as Tuples of `dim.name`s using the `:data_dims` Attribute.
+Variables may then specify data dimensions as a list of names using the `:data_dims` Variable Attribute.
 """
 function set_data_dimension!(domain::Domain, dim::NamedDimension; allow_exists=false)
 
@@ -195,7 +201,7 @@ function allocate_variables!(
             for dimname in get_attribute(v, :data_dims)
         )
     
-        # eltype usually is eltype(modeldata), but can be overriden by :datatype attribute 
+        # eltype usually is eltype(modeldata), but can be overridden by :datatype attribute 
         # (can be used by a Reaction to define a fixed type eg Float64 for a constant Property)
         mdeltype = get_attribute(v, :datatype, eltype(modeldata))
         if mdeltype isa AbstractString

--- a/src/PALEOboxes.jl
+++ b/src/PALEOboxes.jl
@@ -23,6 +23,7 @@ module PALEOboxes
 import YAML
 import Graphs # formerly LightGraphs
 import DataFrames
+using DocStringExtensions
 
 include("utils/DocStrings.jl")
 

--- a/src/ReactionFactory.jl
+++ b/src/ReactionFactory.jl
@@ -56,7 +56,7 @@ end
 
 Create a `ReactionType` and set `base` field.
 
-Default implementation may be overriden to eg set additional fields
+Default implementation may be overridden to eg set additional fields
 """
 function create_reaction(ReactionType::Type{<:AbstractReaction}, base::ReactionBase)
     return ReactionType(base=base)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -38,14 +38,6 @@ abstract type AbstractReactionMethod
 end
 
 
-"""
-    AbstractReaction
-
-Base Type for Reactions.
-
-# Implementation
-Derived types should include a field `base::`[`ReactionBase`](@ref)
-"""
 abstract type AbstractReaction
 end
 
@@ -102,13 +94,7 @@ Enumeration of `VariableBase` subtypes. Allowed values:
     VT_DomContribTarget
 end
 
-"""
-    VariableDomain
 
-Host ([`Domain`](@ref)) model variable.
-
-See also: [`VariableDomPropDep`](@ref), [`VariableDomContribTarget`](@ref)
-"""
 abstract type VariableDomain <: VariableBase
 end
 
@@ -133,11 +119,6 @@ Return an [`AbstractMesh`](@ref) for PALEO object `obj`
 """
 function get_mesh end
 
-"""
-    AbstractCellRange
-
-Defines a range of cells within a [`Domain`](@ref)
-"""
 abstract type AbstractCellRange
 end
 
@@ -196,8 +177,7 @@ function get_table end
 Defines a list of [`ReactionMethod`](@ref) with corresponding [`CellRange`](@ref)
 and views on Variable data (sub)arrays.
 """
-struct ReactionMethodDispatchList{MF <:Tuple, M <:Tuple, V <:Tuple, C <: Tuple}
-    methodfns::MF
+struct ReactionMethodDispatchList{M <:Tuple, V <:Tuple, C <: Tuple}
     methods::M
     vardatas::V
     cellranges::C
@@ -205,8 +185,8 @@ end
 
 # See https://discourse.julialang.org/t/pretty-print-of-type/19555
 # Customize typeof function, as full type name is too verbose (as Tuples are of length ~ number of ReactionMethods to call)
-Base.show(io::IO, ::Type{PALEOboxes.ReactionMethodDispatchList{MF, M, V, C}}) where {MF, M, V, C} = 
-    print(io, "PALEOboxes.ReactionMethodDispatchList{MF::Tuple, M::Tuple, V::Tuple, C::Tuple each of length=$(fieldcount(MF))}")
+Base.show(io::IO, ::Type{PALEOboxes.ReactionMethodDispatchList{M, V, C}}) where {M, V, C} = 
+    print(io, "PALEOboxes.ReactionMethodDispatchList{M::Tuple, V::Tuple, C::Tuple each of length=$(fieldcount(M))}")
 
 "compact form"
 function Base.show(io::IO, dispatchlist::ReactionMethodDispatchList)

--- a/src/VariableDomain.jl
+++ b/src/VariableDomain.jl
@@ -1,5 +1,16 @@
 """
-    VariableDomPropDep
+    VariableDomain <: VariableBase
+
+Abstract base Type for a ([`Domain`](@ref)) model variable.
+    
+Defines a named Variable and corresponding data [`Field`](@ref)s that are linked to by [`VariableReaction`](@ref)s.
+
+See [`VariableDomPropDep`](@ref), [`VariableDomContribTarget`](@ref) 
+"""
+VariableDomain
+
+"""
+    VariableDomPropDep <: VariableDomain
 
 [`Model`](@ref) ([`Domain`](@ref)) `VariableDomain` linking a single `VariableReaction{VT_ReactProperty}`
 to multiple `VariableReaction{VT_ReactDependency}`.
@@ -29,7 +40,7 @@ end
 get_var_type(var::VariableDomPropDep) = VT_DomPropDep
 
 """
-    VariableDomContribTarget
+    VariableDomContribTarget <: VariableDomain
 
 [`Model`](@ref) ([`Domain`](@ref)) `VariableDomain` linking a single `VariableReaction{VT_ReactTarget}`
 to multiple `VariableReaction{VT_ReactContributor}` and `VariableReaction{VT_ReactDependency}`.

--- a/src/reactioncatalog/Fluxes.jl
+++ b/src/reactioncatalog/Fluxes.jl
@@ -358,7 +358,7 @@ function prepare_do_transfer(m::PB.ReactionMethod, (input_vardata, output_vardat
 
     # write diagnostic output
     @info "  active fluxes:"
-    var_inputs, var_outputs = PB.get_variables.(m.vars)
+    var_inputs, var_outputs = PB.get_variables_tuple(m)
     flux_names = m.p
     nactive = 0
     for (var_input, var_output, fluxname) in PB.IteratorUtils.zipstrict(var_inputs, var_outputs, flux_names)
@@ -424,7 +424,7 @@ function prepare_do_transfer(m::PB.ReactionMethod, (input_vardata, output_vardat
         @warn "ReactionMethod $(PB.fullname(m)) no active fluxes found"
     end
      
-    rt = ([v for v in input_vardata_active], [v for v in output_vardata_active]) # recreate Vectors to make them typed
+    rt = ([v for v in input_vardata_active], [v for v in output_vardata_active]) # narrow Types of Vectors
     
     return rt
 end

--- a/src/utils/TestUtils.jl
+++ b/src/utils/TestUtils.jl
@@ -45,8 +45,7 @@ function bench_method(dispatchlist, domainname="", reactionname="", methodname="
 
     # fns, methods, vardatas, crs = dispatchlist
     # iterate through dispatchlist, if names match then benchmark method else just call method
-    for (fn, method, vardata, cr) in PB.IteratorUtils.zipstrict(
-                                        dispatchlist.methodfns, 
+    for (method, vardata, cr) in PB.IteratorUtils.zipstrict(
                                         dispatchlist.methods,
                                         dispatchlist.vardatas, 
                                         dispatchlist.cellranges)
@@ -57,16 +56,16 @@ function bench_method(dispatchlist, domainname="", reactionname="", methodname="
             println(PB.fullname(method), ":")
             if use_time
                 println("    @time:")
-                @time fn(method, vardata[], cr, deltat)
+                @time method.methodfn(method, vardata[], cr, deltat)
             elseif use_btime
                 println("    @btime:")
-                @btime $fn($method, $vardata[], $cr, $deltat)
+                @btime $method.methodfn($method, $vardata[], $cr, $deltat)
             elseif do_code_llvm
                 println("    @code_llvm:")
-                @code_llvm fn(method, vardata[], cr, deltat)
+                @code_llvm method.methodfn(method, vardata[], cr, deltat)
             elseif do_code_native
                 println("    @code_native:")
-                @code_native fn(method, vardata[], cr, deltat)
+                @code_native method.methodfn(method, vardata[], cr, deltat)
             elseif do_code_warntype
                 println("    @code_warntype:")
                 # b = IOBuffer()
@@ -74,10 +73,10 @@ function bench_method(dispatchlist, domainname="", reactionname="", methodname="
                 #    fn, (typeof(method), typeof(vardata[]), typeof(cr), typeof(deltat))
                 #    )
                 # println(String(take!(b)))
-                @code_warntype fn(method, vardata[], cr, deltat)
+                @code_warntype method.methodfn(method, vardata[], cr, deltat)
             end
         elseif call_all
-            fn(method, vardata[], cr, deltat)
+            method.methodfn(method, vardata[], cr, deltat)
         end
         
     end


### PR DESCRIPTION
- Remove unused field from dispatch lists
- Rename ReactionMethod vars -> varlists for consistency (also uses in VariableReaction.jl)
- Replace Tuple where type stability is not needed
- Update doc