### PR TITLE
Simplify Parameters access, provide Parameters to ReactionMethod

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -487,7 +487,7 @@ function dispatch_setup(
 
     for (method, vardata) in modeldata.sorted_methodsdata_setup
         for cr in _dispatch_cellranges(method, cellranges)
-           method.methodfn(method, vardata[], cr, attribute_name)
+           call_method(method, vardata[], cr, attribute_name)
         end
     end
 
@@ -596,7 +596,7 @@ function emits unrolled code with a function call for each Tuple element.
     for j=1:fieldcount(M)
         push!(ex.args,
             quote
-                dl.methods[$j].methodfn(dl.methods[$j], dl.vardatas[$j][], dl.cellranges[$j], deltat)
+                call_method(dl.methods[$j], dl.vardatas[$j][], dl.cellranges[$j], deltat)
             end
             )
     end

--- a/src/Parameter.jl
+++ b/src/Parameter.jl
@@ -6,7 +6,7 @@ import Preferences
 
 A reaction parameter of type `T`.
 Create using short names `ParDouble`, `ParInt`, `ParBool`, `ParString`.
-Read value as `<par>.v::T`, set with [`setvalue!`](@ref).
+Read value as `<par>[]`, set with [`setvalue!`](@ref).
 
 Parameters with `external=true` may be set from the Model-level Parameters list, if `name` is present in that list.
 
@@ -26,6 +26,11 @@ mutable struct Parameter{T, ParseFromString} <: AbstractParameter
     frozen::Bool
     external::Bool
 end
+
+# Parameter behaves as a minimal 0D array (NB: doesn't support full Array interface)
+Base.getindex(parameter::Parameter) = parameter.v
+Base.size(parameter::Parameter) = Tuple{}()
+Base.length(parameter::Parameter) = 1
 
 """
     ParDouble(name,  defaultvalue::Float64; units="", description="", external=false)
@@ -115,7 +120,7 @@ end
 
 A reaction parameter of type Vector{T}.
 Create using short names `ParDoubleVec`, `ParStringVec`.
-Values are `<par>.v::Vector{T}`.
+Values are `<par>[i]`.
 Set using standard yaml syntax for a vector eg [1, 2, 3]
 
 `ParseFromString` should usually be `false` (see [`Parameter`](@ref)).
@@ -130,6 +135,16 @@ mutable struct VecParameter{T, ParseFromString} <: AbstractParameter
     frozen::Bool
     external::Bool
 end
+
+# VecParameter behaves as a minimal 1D array (NB: doesn't support full Array interface)
+Base.getindex(p::VecParameter, index) = p.v[index]
+Base.firstindex(p::VecParameter) = firstindex(p.v)
+Base.lastindex(p::VecParameter) = lastindex(p.v)
+Base.size(p::VecParameter) = size(p.v)
+Base.length(p::VecParameter) = length(p.v)
+Base.iterate(p::VecParameter, state=1) = state > length(p) ? nothing : (p.v[state], state+1)
+Base.keys(p::VecParameter) = keys(p.v)
+Base.eltype(::Type{VecParameter{T, ParseFromString}}) where {T, ParseFromString} = T
 
 """
     ParDoubleVec(name, defaultvalue::Vector{Float64}; units="", description="", external=false)

--- a/src/reactioncatalog/FluxPerturb.jl
+++ b/src/reactioncatalog/FluxPerturb.jl
@@ -58,7 +58,7 @@ function PB.register_methods!(rj::ReactionFluxPerturb)
     
     @info "ReactionFluxPerturb.register_methods! $(PB.fullname(rj))"
 
-    IsotopeType = rj.pars.field_data.v
+    IsotopeType = rj.pars.field_data[]
     PB.setfrozen!(rj.pars.field_data)
 
     vars = [
@@ -87,7 +87,8 @@ function PB.register_methods!(rj::ReactionFluxPerturb)
 end
 
 function setup_flux_perturb(
-    m::PB.ReactionMethod, 
+    m::PB.ReactionMethod,
+    pars,
     _,
     cellrange::PB.AbstractCellRange,
     attribute_name,
@@ -100,15 +101,15 @@ function setup_flux_perturb(
     IsotopeType = m.p
 
     rj.interp_Ftotal = Interpolations.LinearInterpolation(
-        rj.pars.perturb_times.v, 
-        rj.pars.perturb_totals.v,
+        pars.perturb_times[:], 
+        pars.perturb_totals[:],
         extrapolation_bc = Interpolations.Throw()
     )
 
     if IsotopeType <: PB.AbstractIsotopeScalar
         rj.interp_Fdelta = Interpolations.LinearInterpolation(
-            rj.pars.perturb_times.v, 
-            rj.pars.perturb_deltas.v,
+            pars.perturb_times[:], 
+            pars.perturb_deltas[:],
             extrapolation_bc = Interpolations.Throw()
         )
     end
@@ -170,7 +171,7 @@ end
 function PB.register_methods!(rj::ReactionRestore)
   
     PB.setfrozen!(rj.pars.field_data)
-    IsotopeType = rj.pars.field_data.v   
+    IsotopeType = rj.pars.field_data[]
 
     vars = [
         PB.VarDepScalar(    "WatchLevel",                   "mol",      "level to observe and restore",
@@ -196,11 +197,11 @@ function do_restore(m::PB.ReactionMethod, (vars, ), cellrange::PB.AbstractCellRa
     rj = m.reaction    
     IsotopeType = m.p
 
-    requiredlevelisotope = @PB.isotope_totaldelta(IsotopeType, rj.pars.RequiredLevel.v, rj.pars.RequiredDelta.v)
+    requiredlevelisotope = @PB.isotope_totaldelta(IsotopeType, rj.pars.RequiredLevel[], rj.pars.RequiredDelta[])
 
-    restoreflux = -(vars.WatchLevel[] - requiredlevelisotope)/rj.pars.trestore.v
+    restoreflux = -(vars.WatchLevel[] - requiredlevelisotope)/rj.pars.trestore[]
    
-    if !rj.pars.source_only.v || PB.get_total(restoreflux) > 0
+    if !rj.pars.source_only[] || PB.get_total(restoreflux) > 0
         vars.RestoringApplied[] = restoreflux
         vars.RestoringFlux[]    += restoreflux
     else

--- a/src/reactioncatalog/Forcings.jl
+++ b/src/reactioncatalog/Forcings.jl
@@ -52,22 +52,22 @@ function PB.register_methods!(rj::ReactionForceInterp)
     return nothing
 end
 
-function setup_forceinterp(m::PB.ReactionMethod, _, cellrange::PB.AbstractCellRange, attribute_name)
+function setup_forceinterp(m::PB.ReactionMethod, pars, _, cellrange::PB.AbstractCellRange, attribute_name)
     attribute_name == :setup || return
 
     @info "$(PB.fullname(m)):"
 
     rj = m.reaction
 
-    rj.interp_F = PB.LinInterp(rj.pars.force_times.v)
+    rj.interp_F = PB.LinInterp(pars.force_times.v)
 
     return nothing
 end
 
-function do_forceinterp(m::PB.ReactionMethod, (vars, ), cellrange::PB.AbstractCellRange, deltat)
+function do_forceinterp(m::PB.ReactionMethod, pars, (vars, ), cellrange::PB.AbstractCellRange, deltat)
     rj = m.reaction
-  
-    vars.F[] = PB.interp(rj.interp_F, vars.tforce[], rj.pars.force_values.v)
+
+    vars.F[] = PB.interp(rj.interp_F, vars.tforce[], pars.force_values.v)
    
     return nothing
 end

--- a/src/reactionmethods/RateStoich.jl
+++ b/src/reactionmethods/RateStoich.jl
@@ -201,7 +201,7 @@ function do_react_ratestoich(m::ReactionMethod, (rate, delta, sms_data),  cellra
         # @Infiltrator.infiltrate
 
         if isotype <: AbstractIsotopeScalar
-            eta = etapar.v
+            eta = etapar[]
             @inbounds for idx in cellrange.indices
                 sms_data[idx] += isotope_totaldelta(isotype, stoich*rate[idx], delta[idx] + eta)
             end

--- a/test/ReactionPaleoMockModule.jl
+++ b/test/ReactionPaleoMockModule.jl
@@ -22,18 +22,17 @@ Base.@kwdef mutable struct ReactionPaleoMock{P} <: PB.AbstractReaction
 end
 
 
-function do_stateandeqb(m::PB.ReactionMethod, (vars, ), cellrange::PB.AbstractCellRange, deltat)
+function do_stateandeqb(m::PB.ReactionMethod, pars, (vars, ), cellrange::PB.AbstractCellRange, deltat)
 
     vars.scalar_prop[] = vars.scalar_dep[]  # 25nS, 0 allocations
  
     return nothing
 end
 
-function do_react(m::PB.ReactionMethod, (vars, ), cellrange::PB.AbstractCellRange, deltat)
-    rj = m.reaction
-    
+function do_react(m::PB.ReactionMethod, pars, (vars, ), cellrange::PB.AbstractCellRange, deltat)
+ 
     @inbounds  for i in cellrange.indices
-        vars.phy[i] = rj.pars.par1.v
+        vars.phy[i] = pars.par1[]
     end
 
     return nothing
@@ -43,9 +42,9 @@ end
 function PB.register_methods!(rj::ReactionPaleoMock)
     println("ReactionPaleoMock.register_methods! rj=", rj)
 
-    println("  parint=", rj.pars.parint.v)
-    println("  parbool=", rj.pars.parbool.v)
-    println("  parstring=", rj.pars.parstring.v)
+    println("  parint=", rj.pars.parint[])
+    println("  parbool=", rj.pars.parbool[])
+    println("  parstring=", rj.pars.parstring[])
   
     vars_stateandeqb = [
         PB.VarDepScalar("scalar_dep", "mol m-3", "a scalar dependency"),


### PR DESCRIPTION
Both of these changes are backwards compatible

1) Simplify Parameters access by implementing for Parameter somepar[] and for VecParameter someparvec[i] to
  access value(s). This makes access to Parameters work the same way as access to Variables.
  NB: this is implemented by partially implementing the AbstractArray interface,
  sufficient to allow a VecParameter to be used as an iterator.

2) Pass Parameters as an argument to ReactionMethod functions
  This is to allow future solver updates for parameter sensitivity studies without needing further 
  changes to Reaction implementations.