### PR TITLE
Check variable sizes

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOboxes"
 uuid = "804b410e-d900-4b2a-9ecd-f5a06d4c1fd4"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.20.5"
+version = "0.21.0"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -185,7 +185,21 @@ function get_subdomain(grid::PB.AbstractMesh, subdomainname::AbstractString)
     
     return subdomain
 end
-    
+ 
+
+"""
+    internal_size(grid::PB.AbstractMesh [, subdomainname::AbstractString]) -> size::NTuple{Int}
+
+Get Domain or SubDomain size
+"""
+function  PB.internal_size(grid::Union{PB.AbstractMesh, Nothing}, subdomainname::AbstractString)
+    if isempty(subdomainname)
+        return PB.internal_size(grid)
+    else
+        subdomain = get_subdomain(grid, subdomainname)
+        return (length(subdomain.indices),)
+    end
+end
 
 ###################################
 # Fallbacks for Domain with no grid
@@ -193,6 +207,9 @@ end
 
 # allow Vector variables length 1 in a 0D Domain without a grid
 PB.internal_size(grid::Nothing) = (1, )
+# PB.internal_size(grid::Nothing, subdomainname::AbstractString) = _internal_size(grid, subdomainname)
+
+get_subdomain(grid::Nothing, subdomainname::AbstractString) = error("get_subdomain: no subdomain $subdomainname")
 
 """
     create_default_cellrange(domain, grid::Nothing [; operatorID=0]) -> CellRange
@@ -239,6 +256,7 @@ function Base.show(io::IO, grid::UnstructuredVectorGrid)
 end
 
 PB.internal_size(grid::UnstructuredVectorGrid) = (grid.ncells, )
+# PB.internal_size(grid::UnstructuredVectorGrid, subdomainname::AbstractString) = _internal_size(grid, subdomainname)
 
 """
     get_region(grid::UnstructuredVectorGrid, values; cell) -> 
@@ -306,7 +324,7 @@ function Base.show(io::IO, grid::UnstructuredColumnGrid)
 end
 
 PB.internal_size(grid::UnstructuredColumnGrid) = (grid.ncells, )
-
+# PB.internal_size(grid::UnstructuredColumnGrid, subdomainname::AbstractString) = _internal_size(grid, subdomainname)
 
 """
     get_region(grid::UnstructuredColumnGrid, values; column, [cell=nothing]) -> 
@@ -419,6 +437,8 @@ function Base.show(io::IO, grid::CartesianLinearGrid)
 end
 
 PB.internal_size(grid::CartesianLinearGrid) = (grid.ncells, )
+# PB.internal_size(grid::CartesianLinearGrid, subdomainname::AbstractString) = _internal_size(grid, subdomainname)
+
 PB.cartesian_size(grid::CartesianLinearGrid) = Tuple(grid.dims)
 
 
@@ -465,6 +485,8 @@ function Base.show(io::IO, grid::CartesianArrayGrid)
 end
 
 PB.internal_size(grid::CartesianArrayGrid) = Tuple(grid.dims)
+# PB.internal_size(grid::CartesianArrayGrid, subdomainname::AbstractString) = _internal_size(grid, subdomainname)
+
 PB.cartesian_size(grid::CartesianArrayGrid) = Tuple(grid.dims)
 
 

--- a/src/VariableAttributes.jl
+++ b/src/VariableAttributes.jl
@@ -129,9 +129,9 @@ const StandardAttributes = [
     Attribute{Type, AbstractData}(        :field_data,           UndefinedData,   true,       "",         "AbstractData type Variable contains")    
     Attribute{Tuple{Vararg{String}}, Tuple{Vararg{String}}}(
                                           :data_dims,            (),              true,       "",         "Variable data dimensions, or empty for a scalar")
-    Attribute{Type, AbstractSpace}(       :space,                CellSpace,       true,       "",           "function space Variable is defined on")
-    Attribute{String, Nothing}(           :mesh,                 "default",       true,       "",  "Mesh on which Variable is defined (empty for Domain spatial scalar)")
-
+    Attribute{Type, AbstractSpace}(       :space,                CellSpace,       true,       "",         "function space Variable is defined on")
+    Attribute{String, Nothing}(           :mesh,                 "default",       true,       "",         "Mesh on which Variable is defined (empty for Domain spatial scalar)")
+    Attribute{Bool, Nothing}(             :check_length,         true,            false,      "",         "true to check length matches length of linked VariableDomain")
 
     Attribute{VariableFunction, VariableFunction}(
                                           :vfunction,             VF_Undefined,   true,       "",         "host function")

--- a/src/VariableAttributes.jl
+++ b/src/VariableAttributes.jl
@@ -5,12 +5,13 @@
 #####################################################
 
 """
-    set_attribute!(var::VariableBase, name::Symbol, value, allow_create=false)
+    set_attribute!(var::VariableBase, name::Symbol, value, allow_create=false) -> var
 
 Set Variable attribute.
 """
 function set_attribute!(var::VariableBase, name::Symbol, value; allow_create=false)
-    return _set_attribute!(var.attributes, name, value, allow_create)
+    _set_attribute!(var.attributes, name, value, allow_create)
+    return var
 end
 
 """

--- a/src/VariableDomain.jl
+++ b/src/VariableDomain.jl
@@ -101,6 +101,7 @@ function host_dependent(var::VariableDomContribTarget)
     return isnothing(var.var_target)
 end
 
+
 ################################################
 # Field and data access
 ##################################################
@@ -228,6 +229,8 @@ function allocate_variables!(
 )
     
     for v in vars
+        check_lengths(v)
+
         data_dims = Tuple(
             get_data_dimension(v.domain, dimname) 
             for dimname in get_attribute(v, :data_dims)
@@ -291,6 +294,28 @@ function reallocate_variables!(vars, modeldata, new_eltype)
     end
 
     return reallocated_variables
+end
+
+
+function check_lengths(var::VariableDomain)
+
+    var_space = get_attribute(var, :space)
+    var_scalar = (var_space == ScalarSpace)
+    var_size = var_scalar ? (1, ) : internal_size(var.domain.grid)
+    for lv in get_all_links(var)
+        if get_attribute(lv, :check_length, true)
+            link_space = get_attribute(lv, :space)
+            link_scalar = (link_space == ScalarSpace)
+            link_size = link_scalar ? (1, ) : internal_size(lv.method.domain.grid)
+
+            var_size == link_size || 
+                error("check_lengths: VariableDomain $(fullname(var)), :space=$var_space size=$var_size "*
+                    "!= $(fullname(lv)), :space=$link_space size=$link_size (check size of Domains $(var.domain.name), $(lv.method.domain.name) "*
+                    "and Variable :space")
+        end
+    end
+
+    return nothing
 end
 
 ####################################################################

--- a/src/VariableDomain.jl
+++ b/src/VariableDomain.jl
@@ -296,22 +296,28 @@ function reallocate_variables!(vars, modeldata, new_eltype)
     return reallocated_variables
 end
 
+"""
+    check_lengths(var::VariableDomain)
 
+Check that sizes of all linked Variables match
+"""
 function check_lengths(var::VariableDomain)
 
     var_space = get_attribute(var, :space)
     var_scalar = (var_space == ScalarSpace)
-    var_size = var_scalar ? (1, ) : internal_size(var.domain.grid)
+    
     for lv in get_all_links(var)
         if get_attribute(lv, :check_length, true)
+            var_size = var_scalar ? (1, ) : internal_size(var.domain.grid, lv.linkreq_subdomain)
+
             link_space = get_attribute(lv, :space)
             link_scalar = (link_space == ScalarSpace)
             link_size = link_scalar ? (1, ) : internal_size(lv.method.domain.grid)
 
             var_size == link_size || 
                 error("check_lengths: VariableDomain $(fullname(var)), :space=$var_space size=$var_size "*
-                    "!= $(fullname(lv)), :space=$link_space size=$link_size (check size of Domains $(var.domain.name), $(lv.method.domain.name) "*
-                    "and Variable :space")
+                    "!= $(fullname(lv)), :space=$link_space size=$link_size created by $(typename(lv.method.reaction)) (check size of Domains $(var.domain.name), $(lv.method.domain.name), "*
+                    "$(isempty(lv.linkreq_subdomain) ? "" : "subdomain "*lv.linkreq_subdomain*",") and Variables :space)")
         end
     end
 

--- a/src/reactioncatalog/Fluxes.jl
+++ b/src/reactioncatalog/Fluxes.jl
@@ -316,23 +316,23 @@ function PB.register_dynamic_methods!(rj::ReactionFluxTransfer, model::PB.Model)
                 input_var.name
             )
             input_attrb = Tuple(atnm=>PB.get_attribute(input_var, atnm) for atnm in (:field_data, :data_dims, :space))
-           
-            push!(var_inputs, 
-                PB.VarDep("input_"*fluxname => input_namestr, "mol yr-1", "flux input",           
-                    attributes=input_attrb,
-                )
+            v_input = PB.VarDep("input_"*fluxname => input_namestr, "mol yr-1", "flux input",           
+                attributes=input_attrb,
             )
+            if rj.pars.transfer_matrix[] != "Identity"
+                PB.set_attribute!(v_input, :check_length, false; allow_create=true)
+            end
+            push!(var_inputs, v_input)
 
             output_namestr = "("*PB.combine_link_name(
                 output_domain_name, 
                 output_subdomain_name, 
                 replace(output_var_patternname, "\$fluxname\$" => fluxname)
             )*")"
-            push!(var_outputs, 
-                PB.VarContrib("output_"*fluxname => output_namestr, "mol yr-1", "flux output",
-                    attributes=input_attrb,
-                )
+            v_output = PB.VarContrib("output_"*fluxname => output_namestr, "mol yr-1", "flux output",
+                attributes=input_attrb,
             )
+            push!(var_outputs, v_output)
         else
             @debug "  ignoring $(PB.fullname(input_var))"
         end

--- a/src/reactioncatalog/VariableStats.jl
+++ b/src/reactioncatalog/VariableStats.jl
@@ -68,11 +68,16 @@ function PB.register_methods!(rj::ReactionSum)
         (linkreq_domain, linkreq_subdomain, linkreq_name, link_optional) =
             PB.parse_variablereaction_namestr(varname)
         localname = PB.combine_link_name(linkreq_domain, "", linkreq_name, sep="_")
-         # mark all vars_to_add as optional to help diagnose config errors
-         # default :field_data=>PB.UndefinedData  to allow Variable to link to any data type (this is checked later)
-        push!(vars_to_add, 
-            PB.VarDep(localname => "("*varname*")", "", "")
-        )
+
+        # mark all vars_to_add as optional to help diagnose config errors
+        # default :field_data=>PB.UndefinedData  to allow Variable to link to any data type (this is checked later)
+        v =  PB.VarDep(localname => "("*varname*")", "", "")
+
+        # no length check if scalar sum
+        if !rj.pars.vectorsum[]
+            PB.set_attribute!(v, :check_length, false; allow_create=true)
+        end
+        push!(vars_to_add, v)
     end
 
     if rj.pars.vectorsum[]


### PR DESCRIPTION
Fix for issue https://github.com/PALEOtoolkit/PALEOboxes.jl/issues/51

Sizes of all linked Variables are now checked, by checking that
the size of the ReactionMethod Domain for a VariableReaction matches
the size of the VariableDomain that it is linked to.


It is possible to opt-out of this check by setting the VariableAttribute
:check_length=false. This is needed for a few cases including:

- a ReactionMethod in an interior Domain calculates boundary fluxes assuming
  a regular column grid, and needs to add them to a surface or floor
  Variable: the surface/floor Variable will need the :check_length=false
  attribute, as it is not the same size as the interior Domain.

- a setup ReactionMethod configures all grid variables, including
  both interior and boundary Variables (which will need the :check_length=false
  attribute).

If it is necessary to use the :check_length=false attribute, then
any loop that accesses these Variables should not use @inbounds so that
the low-level Julia checks will still catch configuration errors.
