### PR TITLE
Define a new ColumnSpace <: AbstractSpace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOboxes"
 uuid = "804b410e-d900-4b2a-9ecd-f5a06d4c1fd4"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.21.0"
+version = "0.21.1"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"

--- a/src/Fields.jl
+++ b/src/Fields.jl
@@ -21,9 +21,17 @@ end
 """
     CellSpace <: AbstractSpace
 
-A per-cell quantity. Use as Variable attribute :space to create a Variable with data array dimensions from Grid
+A per-cell quantity. Use as Variable attribute :space to create a Variable with data array dimensions from Grid cells.
 """
 struct CellSpace <: AbstractSpace
+end
+
+"""
+    ColumnSpace <: AbstractSpace
+
+A per-column quantity. Use as Variable attribute :space to create a Variable with data array dimensions from Grid columns.
+"""
+struct ColumnSpace <: AbstractSpace
 end
 
 
@@ -51,11 +59,14 @@ end
 #################################################################
 
 """
-    internal_size(mesh::AbstractMesh) -> NTuple{ndims, Int}
+    internal_size(::Type{<:AbstractSpace}, mesh::AbstractMesh; [subdomain=""] [space=:cell]) -> NTuple{ndims, Int}
 
-Array size to use for per-cell model Variables.
+Array size to use for model Variables.
 
 All `AbstractMesh` concrete subtypes (UnstructuredVectorGrid, CartesianLinearGrid, ...) should implement this method.
+
+# Optional Keyword Arguments
+- `subdomain::String=""`: a named subdomain  
 """
 function internal_size end
 
@@ -74,8 +85,7 @@ function cartesian_size end
 
 Array size for given Space and mesh.
 """
-spatial_size(::Type{ScalarSpace}, mesh) = (1, )
-spatial_size(::Type{CellSpace}, mesh) = internal_size(mesh)
+spatial_size(space::Type{<:AbstractSpace}, mesh) = internal_size(space, mesh)
 
 
 ################################################################

--- a/src/VariableDomain.jl
+++ b/src/VariableDomain.jl
@@ -304,20 +304,24 @@ Check that sizes of all linked Variables match
 function check_lengths(var::VariableDomain)
 
     var_space = get_attribute(var, :space)
-    var_scalar = (var_space == ScalarSpace)
     
     for lv in get_all_links(var)
         if get_attribute(lv, :check_length, true)
-            var_size = var_scalar ? (1, ) : internal_size(var.domain.grid, lv.linkreq_subdomain)
+            try
+                var_size = internal_size(var_space, var.domain.grid, lv.linkreq_subdomain)
 
-            link_space = get_attribute(lv, :space)
-            link_scalar = (link_space == ScalarSpace)
-            link_size = link_scalar ? (1, ) : internal_size(lv.method.domain.grid)
+                link_space = get_attribute(lv, :space)
+                link_size = internal_size(link_space, lv.method.domain.grid)
 
-            var_size == link_size || 
-                error("check_lengths: VariableDomain $(fullname(var)), :space=$var_space size=$var_size "*
-                    "!= $(fullname(lv)), :space=$link_space size=$link_size created by $(typename(lv.method.reaction)) (check size of Domains $(var.domain.name), $(lv.method.domain.name), "*
-                    "$(isempty(lv.linkreq_subdomain) ? "" : "subdomain "*lv.linkreq_subdomain*",") and Variables :space)")
+                var_size == link_size || 
+                    error("check_lengths: VariableDomain $(fullname(var)), :space=$var_space size=$var_size "*
+                        "!= $(fullname(lv)), :space=$link_space size=$link_size created by $(typename(lv.method.reaction)) (check size of Domains $(var.domain.name), $(lv.method.domain.name), "*
+                        "$(isempty(lv.linkreq_subdomain) ? "" : "subdomain "*lv.linkreq_subdomain*",") and Variables :space)")
+            catch
+                error("check_lengths: exception VariableDomain $(fullname(var)), :space=$var_space "*
+                        "linked by $(fullname(lv)), created by $(typename(lv.method.reaction)) (check size of Domains $(var.domain.name), $(lv.method.domain.name), "*
+                        "$(isempty(lv.linkreq_subdomain) ? "" : "subdomain "*lv.linkreq_subdomain*",") and Variables :space)")
+            end
         end
     end
 

--- a/src/VariableReaction.jl
+++ b/src/VariableReaction.jl
@@ -188,11 +188,15 @@ VarPropStateIndep(localname, units, description; attributes::Tuple=(), kwargs...
 
 VarDepScalar(localname, units, description; attributes::Tuple=(), kwargs... ) = 
     VarDep(localname, units, description; attributes=(:space=>ScalarSpace, attributes...), kwargs...)
+VarDepColumn(localname, units, description; attributes::Tuple=(), kwargs... ) = 
+    VarDep(localname, units, description; attributes=(:space=>ColumnSpace, attributes...), kwargs...)
 VarDep(localname, units, description; kwargs... ) = 
     CreateVariableReaction(VT_ReactDependency, localname, units, description; kwargs...)
     
 VarDepScalarStateIndep(localname, units, description; attributes::Tuple=(), kwargs... ) =
     VarDepScalar(localname, units, description; attributes=(attributes..., :datatype=>Float64), kwargs...)
+VarDepColumnStateIndep(localname, units, description; attributes::Tuple=(), kwargs... ) =
+    VarDepColumn(localname, units, description; attributes=(attributes..., :datatype=>Float64), kwargs...)
 VarDepStateIndep(localname, units, description; attributes::Tuple=(), kwargs...) =
     VarDep(localname, units, description; attributes=(attributes..., :datatype=>Float64),  kwargs...)
 
@@ -221,6 +225,8 @@ VarTarget(localname, units, description; attributes::Tuple=(), kwargs... ) =
         
 VarContribScalar(localname, units, description; attributes::Tuple=(), kwargs... ) = 
     VarContrib(localname, units, description; attributes=(:space=>ScalarSpace, attributes...), kwargs...)
+VarContribColumn(localname, units, description; attributes::Tuple=(), kwargs... ) = 
+    VarContrib(localname, units, description; attributes=(:space=>ColumnSpace, attributes...), kwargs...)
 VarContrib(localname, units, description; kwargs... ) = 
     CreateVariableReaction(VT_ReactContributor, localname, units, description; kwargs...)
 

--- a/src/reactioncatalog/Fluxes.jl
+++ b/src/reactioncatalog/Fluxes.jl
@@ -441,13 +441,13 @@ function do_transfer(
     function _transfer(acinput, acoutput, tm_tr, cr)
         if length(acoutput) == 1
             # Scalar Variables, (we have already checked size(tm_tr, 2) == 1)
-            @inbounds for idx in SparseArrays.nzrange(tm_tr, 1)
+            for idx in SparseArrays.nzrange(tm_tr, 1)
                 i = tm_tr.rowval[idx]
                 acoutput[1] += acinput[i]*tm_tr.nzval[idx]
             end
         else
             for j in cr.indices
-                @inbounds for idx in SparseArrays.nzrange(tm_tr, j)
+                for idx in SparseArrays.nzrange(tm_tr, j)
                     i = tm_tr.rowval[idx]
                     acoutput[j] += acinput[i]*tm_tr.nzval[idx]
                 end

--- a/src/reactioncatalog/GridForcings.jl
+++ b/src/reactioncatalog/GridForcings.jl
@@ -160,7 +160,7 @@ function _prepare_data(rj::ReactionForceGrid, ds)
     # to the n-D cartesian_size of the forcings read from the NetCDF file 
     ncartesiandims = length(PB.cartesian_size(rj.domain.grid))  # as read from NetCDF
     cartesiancolons = fill(Colon(), ncartesiandims)
-    ninternaldims = length(PB.internal_size(rj.domain.grid)) # PALEO array layout
+    ninternaldims = length(PB.internal_size(PB.CellSpace, rj.domain.grid)) # PALEO array layout
     internalcolons = fill(Colon(), ninternaldims)
 
     ninterpdims = length(rj.pars.interp_vars)
@@ -170,7 +170,7 @@ function _prepare_data(rj::ReactionForceGrid, ds)
     # map to grid internal storage (ie mapping ncartesiandims -> ninternaldims)
     #           grid             interp           time
     data_ndims = ninternaldims + length(interpdims) + 1
-    rj.data_var = Array{Float64, data_ndims}(undef, PB.internal_size(rj.domain.grid)..., interpdims..., num_time_recs)
+    rj.data_var = Array{Float64, data_ndims}(undef, PB.internal_size(PB.CellSpace, rj.domain.grid)..., interpdims..., num_time_recs)
     @info "  size(data_var) = $(size(rj.data_var))"
         
     # TODO - reorder indices (currently require  gridvars..., interpvars..., timevar)


### PR DESCRIPTION
This enables Variable length checks for Reactions using column-based grids
to accumulate fluxes etc into top or bottom boundary Domains.

This means it is now possible to check that a grid defines columns, and
that number of columns == number of cells in boundaries.

Currently this only supports Dependency and Contributor Variables,
(ie it's not yet possible to create a ColumnSpace Variable).