### PR TITLE
Reduce startup time, update Project.toml for v0.21.3

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PALEOboxes"
 uuid = "804b410e-d900-4b2a-9ecd-f5a06d4c1fd4"
 authors = ["Stuart Daines <stuart.daines@gmail.com>"]
-version = "0.21.2"
+version = "0.21.3"
 
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
@@ -25,6 +25,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 StructArrays = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
 TestEnv = "1e6cf692-eddd-4d53-88a5-2d735e33781b"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 YAML = "ddb6d928-2868-570f-bddf-ab3f9cf99eb6"
 
 [compat]
@@ -46,6 +47,7 @@ SnoopPrecompile = "1.0"
 StaticArrays = "1.4"
 StructArrays = "0.6"
 TestEnv = "1.0"
+TimerOutputs = "1.5"
 YAML = "0.4.7"
 julia = "1.6"
 

--- a/src/PALEOboxes.jl
+++ b/src/PALEOboxes.jl
@@ -27,6 +27,7 @@ using DocStringExtensions
 import OrderedCollections
 
 import SnoopPrecompile
+import TimerOutputs: @timeit
 
 include("utils/DocStrings.jl")
 

--- a/src/Reaction.jl
+++ b/src/Reaction.jl
@@ -329,16 +329,16 @@ add_method_initialize!(@nospecialize(reaction::AbstractReaction), methodfn::Func
 Add or create and add a main loop method.
 `methodfn`, `vars`, `kwargs` are passed to [`ReactionMethod`](@ref).
 """
-function add_method_do!(@nospecialize(reaction::AbstractReaction), method::AbstractReactionMethod)
+function add_method_do!(@nospecialize(reaction::AbstractReaction), @nospecialize(method::AbstractReactionMethod))
     push!(reaction.base.methods_do, method)
     return nothing
 end
 
-add_method_do!(@nospecialize(reaction::AbstractReaction), methodfn::Function, vars::Tuple{Vararg{AbstractVarList}}; kwargs...) = 
+add_method_do!(@nospecialize(reaction::AbstractReaction), @nospecialize(methodfn::Function), @nospecialize(vars::Tuple{Vararg{AbstractVarList}}); kwargs...) = 
     _add_method!(reaction, methodfn, vars, add_method_do!; kwargs...)
 
 function _add_method!(
-    @nospecialize(reaction::AbstractReaction), methodfn::Function, vars::Tuple{Vararg{AbstractVarList}}, add_method_fn;
+    @nospecialize(reaction::AbstractReaction), @nospecialize(methodfn::Function), @nospecialize(vars::Tuple{Vararg{AbstractVarList}}), add_method_fn;
     name=string(methodfn),
     p=nothing,
     preparefn=(m, vardata) -> vardata,

--- a/src/ReactionMethod.jl
+++ b/src/ReactionMethod.jl
@@ -102,6 +102,8 @@ struct ReactionMethod{M, R, P, V, Nargs} <: AbstractReactionMethod
     end
 end
 
+get_nargs(method::ReactionMethod{M, R, P, V, Nargs}) where {M, R, P, V, Nargs} = Nargs
+get_nargs(methodref::Ref{ReactionMethod{M, R, P, V, Nargs}}) where {M, R, P, V, Nargs} = Nargs
 # deprecated form without pars
 @inline call_method(method::ReactionMethod{M, R, P, V, 4}, vardata, cr, modelctxt) where {M, R, P, V} = 
     method.methodfn(method, vardata, cr, modelctxt)

--- a/src/Types.jl
+++ b/src/Types.jl
@@ -180,6 +180,12 @@ struct ReactionMethodDispatchList{M <:Tuple, V <:Tuple, C <: Tuple}
     cellranges::C
 end
 
+struct ReactionMethodDispatchListNoGen
+    methods::Vector
+    vardatas::Vector
+    cellranges::Vector
+end
+
 # See https://discourse.julialang.org/t/pretty-print-of-type/19555
 # Customize typeof function, as full type name is too verbose (as Tuples are of length ~ number of ReactionMethods to call)
 Base.show(io::IO, ::Type{PALEOboxes.ReactionMethodDispatchList{M, V, C}}) where {M, V, C} = 


### PR DESCRIPTION
- Add timing info using TimerOutputs

- Option to RateStoich to allow it to be called as a function instead of a standalone method (to reduce number of methods generated)

- initialize_reactiondata! option to only create dispatchlists_all when needed

- ReactionMethodDispatchList use Ref - this seems to trade off time to create ReactionMethodDispatchList and time for first call to do_deriv, where Ref gives fast ReactionMethodDispatchList creation, but slow first do_deriv.