### PR TITLE
VariableAggregator updates

### DIFF
--- a/docs/src/Solver API.md
+++ b/docs/src/Solver API.md
@@ -29,6 +29,7 @@ ReactionMethodDispatchList
 High-level access to aggregated collections of Variables is provided by [`VariableAggregator`](@ref) and [`VariableAggregatorNamed`](@ref) (see [Accessing model objects](@ref) for low-level access).
 ```@docs
 VariableAggregator
+get_indices
 copyto!(dest::VariableAggregator, src::AbstractVector; sof::Int=1)
 copyto!(dest::AbstractVector, src::VariableAggregator; dof::Int=1)
 


### PR DESCRIPTION
- get_indices(va::VariableAggregator, varnamefull::AbstractString; allow_not_found=false) -> indices::UnitRange{Int64} to find indices in flattened vector

- VariableAggregatorNamed(va::VariableAggregator; ignore_cellranges=false) to create a VAN from VA