### PR TITLE
Fix variable linking for ReactionMethod not in reaction Domain

### DIFF
--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -502,7 +502,7 @@ function _link_variables!(domain::Domain, model::Model, oper, dolog)
         for var in get_variables(react)
 
             if isempty(var.linkreq_domain)
-                linkvar_domain = domain
+                linkvar_domain = var.method.domain
             else
                 linkvar_domain = get_domain(model, var.linkreq_domain)
                 !isnothing(linkvar_domain) || 


### PR DESCRIPTION
When a method is added in a different domain to the reaction, then any VariableReaction that is added should default to the Domain of the ReactionMethod, not of the reaction