### PR TITLE
Fix yaml parse failure with concatenated files

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -226,7 +226,7 @@ function create_model_from_config(
     yamltext = ""
     for fn in config_files
         isfile(fn) || error("config file $(abspath(fn)) not found")
-        yamltext *= read(fn, String)
+        yamltext *= read(fn, String) * "\n" # add newline so concatenation correct if one file doesn't have a blank line at end
     end
 
     data = nothing

--- a/test/configbase_pt1.yaml
+++ b/test/configbase_pt1.yaml
@@ -1,0 +1,13 @@
+model1:
+    parameters:
+        model_par1: 0.15
+    domains:
+        ocean:
+
+            reactions:
+                julia_paleo_mock:
+                    class: ReactionPaleoMock
+                    parameters:
+                        par1:          external%model_par1           # double parameter
+                    variable_links:
+                        phy*:      mock_phy*

--- a/test/configbase_pt2.yaml
+++ b/test/configbase_pt2.yaml
@@ -1,0 +1,17 @@
+                julia_paleo_mock2:
+                    class: ReactionPaleoMock
+                    
+                    parameters:
+                        par1:          external%model_par1           # double parameter
+                    variable_links:
+                        scalar_dep:     julia_paleo_mock/scalar_prop
+                        phy*:    mock2_phy*
+
+        oceansurface:
+            reactions:
+
+        oceanfloor:
+            reactions:
+
+
+

--- a/test/runbasetests.jl
+++ b/test/runbasetests.jl
@@ -116,3 +116,11 @@ end
     @test length(model.domains) == 3
    
 end
+
+# test parsing concatenated yaml files
+@testset "PALEOboxes base concatenate" begin
+    model = PB.create_model_from_config(["configbase_pt1.yaml", "configbase_pt2.yaml"], "model1")
+
+    @test length(model.domains) == 3
+
+end


### PR DESCRIPTION
Fix for https://github.com/PALEOtoolkit/PALEOboxes.jl/issues/66 

Parse failed if using multiple files, and one of the files didn't have a blank line at end.