### PR TITLE
Fix for const ReactionReservoirScalar

### DIFF
--- a/src/reactioncatalog/Reservoirs.jl
+++ b/src/reactioncatalog/Reservoirs.jl
@@ -103,8 +103,12 @@ function PB.register_methods!(rj::ReactionReservoirScalar)
     end
     PB.setfrozen!(rj.pars.const)
 
+    # don't include R_sms here, as if it is a VarTarget (constant case) that then creates a loop if some other reaction
+    # tries to read R and write R_sms
+    do_vars = [R, PB.VarPropScalar("R_norm", "", "scalar reservoir normalized")]
     # sms variable not used by us, but must appear in a method to be linked and created
-    do_vars = [R, R_sms, PB.VarPropScalar("R_norm", "", "scalar reservoir normalized")]
+    PB.add_method_do_nothing!(rj, [R_sms])
+
     if rj.pars.field_data[] <: PB.AbstractIsotopeScalar
         push!(do_vars, PB.VarPropScalar("R_delta", "per mil", "scalar reservoir isotope delta"))
     end

--- a/test/ReactionReservoirFlux.jl
+++ b/test/ReactionReservoirFlux.jl
@@ -1,0 +1,31 @@
+module ReactionRateStoichMockModule
+
+import PALEOboxes as PB
+
+"Mock Reaction to test calculating a flux that depends on a reservoir"
+Base.@kwdef mutable struct ReactionReservoirFlux <: PB.AbstractReaction
+    base::PB.ReactionBase
+
+end
+
+function PB.register_methods!(rj::ReactionReservoirFlux)
+
+    vars = [
+        PB.VarDepScalar("R", "mol", "a scalar reservoir"),
+        PB.VarContribScalar("R_sms", "mol yr-1", "a scalar reservoir source-sink"),
+    ]
+    PB.add_method_do!(rj, do_reservoirflux, (PB.VarList_namedtuple(vars),))
+
+    return nothing
+end
+
+function do_reservoirflux(m, (vars, ), cellrange::PB.AbstractCellRange, deltat)
+
+    flux = 1.0*vars.R[] # first order rate
+    vars.R_sms[] -= flux
+  
+    return nothing
+end
+
+
+end # module

--- a/test/configreservoirsfluxes.yaml
+++ b/test/configreservoirsfluxes.yaml
@@ -1,0 +1,42 @@
+
+# test that model links correctly with
+# - reservoir and flux depending on that reservoir
+# - constant reservoir and flux depending on that reservoir
+model1:
+
+    domains:
+        global:
+            
+            reactions:
+            
+                reservoir_O:
+                    class: ReactionReservoirScalar
+                   
+                    variable_links:
+                        R*: O*
+                    variable_attributes:
+                        R:norm_value:           3.7e18
+                        R:initial_value:        3.7e19
+
+                reservoir_ConstS:
+                    class: ReactionReservoirScalar
+                   
+                    parameters:
+                        const:                  true
+                    variable_links:
+                        R*: ConstS*
+                    variable_attributes:
+                        R:norm_value:           10.0
+                        R:initial_value:        1.0
+
+                flux_O:
+                    class: ReactionReservoirFlux
+                    variable_links:
+                        R*:    O*
+
+                flux_constS:
+                    class: ReactionReservoirFlux
+                    variable_links:
+                        R*:    ConstS*
+
+        

--- a/test/runreservoirtests.jl
+++ b/test/runreservoirtests.jl
@@ -6,6 +6,8 @@ import PALEOboxes as PB
 
 import Infiltrator
 
+include("ReactionReservoirFlux.jl")
+
 @testset "Reactions" begin
     @test PB.find_reaction("ReactionReservoirScalar") == PB.Reservoirs.ReactionReservoirScalar
 
@@ -124,5 +126,14 @@ end
 
     @info "test complete"
     # close(logfile)
+
+end
+
+
+@testset "ReservoirsFluxes" begin
+
+    # test is just that the model links correctly with flux and a constant ReactionReservoirScalar 
+
+    model =  PB.create_model_from_config("configreservoirsfluxes.yaml", "model1")
 
 end


### PR DESCRIPTION
Problem was introduced in https://github.com/PALEOtoolkit/PALEOboxes.jl/pull/74

ReactionReservoirScalar shouldn't add R_sms variable to do_reactionreservoirscalar method, as that fails if const=true (where R_sms is than a VarTargetScalar) and another reaction that depends on R also tries to write R_sms (creates a dependency loop).