### PR TITLE
Remove :mesh, :initialize_to_zero from required VariableAttributes

### DIFF
--- a/src/VariableAttributes.jl
+++ b/src/VariableAttributes.jl
@@ -143,7 +143,7 @@ const StandardAttributes = [
     Attribute{Type, AbstractSpace}(       :space,                CellSpace,       true,       "",         "function space Variable is defined on")
     Attribute{String, Nothing}(           :mesh,                 "default",       true,       "",         "grid mesh on which Variable is defined (empty for Domain spatial scalar)")
     Attribute{Bool, Nothing}(             :check_length,         true,            false,      "",         "true to check length matches length of linked VariableDomain")
-
+    Attribute{Bool, Nothing}(             :is_constant,          false,           true,      "",          "true if variable is not changed after initialisation")
     Attribute{VariableFunction, VariableFunction}(
                                           :vfunction,             VF_Undefined,   true,       "",         "host function (to label state variables etc)")
     Attribute{Vector{Int}, Nothing}(      :operatorID,            Int[],          false,      "",         "Reaction operatorIDs that modify this Variable")

--- a/src/VariableAttributes.jl
+++ b/src/VariableAttributes.jl
@@ -141,7 +141,7 @@ const StandardAttributes = [
     Attribute{Tuple{Vararg{String}}, Tuple{Vararg{String}}}(
                                           :data_dims,            (),              true,       "",         "Tuple of variable data dimension names, or empty for a scalar")
     Attribute{Type, AbstractSpace}(       :space,                CellSpace,       true,       "",         "function space Variable is defined on")
-    Attribute{String, Nothing}(           :mesh,                 "default",       true,       "",         "grid mesh on which Variable is defined (empty for Domain spatial scalar)")
+    Attribute{String, Nothing}(           :mesh,                 "default",       false,       "",         "grid mesh on which Variable is defined (empty for Domain spatial scalar)")
     Attribute{Bool, Nothing}(             :check_length,         true,            false,      "",         "true to check length matches length of linked VariableDomain")
     Attribute{Bool, Nothing}(             :is_constant,          false,           true,      "",          "true if variable is not changed after initialisation")
     Attribute{VariableFunction, VariableFunction}(
@@ -158,7 +158,7 @@ const StandardAttributes = [
     Attribute{Bool, Nothing}(             :advect,                false,          false,      "",         "true to apply advective transport to this tracer")
     Attribute{Float64, Nothing}(          :advect_zmin,           0.0,            false,      "m",        "minimum height for transport")
     # Attribute{Bool, Nothing}(            :optional,             false,          true,       "",         "")
-    Attribute{Bool, Nothing}(             :initialize_to_zero,    false,          true,       "",         "request initialize to zero at start of each timestep.")
+    Attribute{Bool, Nothing}(             :initialize_to_zero,    false,          false,       "",        "request initialize to zero at start of each timestep.")
     Attribute{Float64, Nothing}(          :vertical_movement,     0.0,            false,      "m d-1",    "vertical advective transport (+ve upwards) in column")
     Attribute{String, Nothing}(           :diffusivity_speciesname, "",           false,      "",         "species name to define diffusivity")
     Attribute{Union{Float64,Vector{Float64}}, Nothing}(

--- a/src/VariableReaction.jl
+++ b/src/VariableReaction.jl
@@ -276,9 +276,9 @@ VarProp(localname, units, description; attributes::Tuple=(), kwargs... ) =
     VariableReaction(VT_ReactProperty, localname, units, description; attributes=(:field_data=>ScalarData, attributes...), kwargs...)
             
 VarPropScalarStateIndep(localname, units, description; attributes::Tuple=(), kwargs... ) =
-    VarPropScalar(localname, units, description; attributes=(attributes..., :datatype=>Float64), kwargs...)
+    VarPropScalar(localname, units, description; attributes=(attributes..., :is_constant=>true, :datatype=>Float64), kwargs...)
 VarPropStateIndep(localname, units, description; attributes::Tuple=(), kwargs...) =
-    VarProp(localname, units, description; attributes=(attributes..., :datatype=>Float64),  kwargs...)
+    VarProp(localname, units, description; attributes=(attributes..., :is_constant=>true, :datatype=>Float64),  kwargs...)
 
 VarDepScalar(localname, units, description; attributes::Tuple=(), kwargs... ) = 
     VarDep(localname, units, description; attributes=(:space=>ScalarSpace, attributes...), kwargs...)
@@ -288,11 +288,11 @@ VarDep(localname, units, description; kwargs... ) =
     VariableReaction(VT_ReactDependency, localname, units, description; kwargs...)
     
 VarDepScalarStateIndep(localname, units, description; attributes::Tuple=(), kwargs... ) =
-    VarDepScalar(localname, units, description; attributes=(attributes..., :datatype=>Float64), kwargs...)
+    VarDepScalar(localname, units, description; attributes=(attributes..., :is_constant=>true, :datatype=>Float64), kwargs...)
 VarDepColumnStateIndep(localname, units, description; attributes::Tuple=(), kwargs... ) =
-    VarDepColumn(localname, units, description; attributes=(attributes..., :datatype=>Float64), kwargs...)
+    VarDepColumn(localname, units, description; attributes=(attributes..., :is_constant=>true, :datatype=>Float64), kwargs...)
 VarDepStateIndep(localname, units, description; attributes::Tuple=(), kwargs...) =
-    VarDep(localname, units, description; attributes=(attributes..., :datatype=>Float64),  kwargs...)
+    VarDep(localname, units, description; attributes=(attributes..., :is_constant=>true, :datatype=>Float64),  kwargs...)
 
 
 # create a VarDep suitable for linking to a VarProp or VarTarget

--- a/src/reactionmethods/SetupInitializeUtilityMethods.jl
+++ b/src/reactionmethods/SetupInitializeUtilityMethods.jl
@@ -145,7 +145,7 @@ NB: TODO variables are converted to VarDep (no dependency checking or sorting ne
 """
 function add_method_initialize_zero_vars_default!(
     react::AbstractReaction, variables=get_variables(react); 
-    filterfn=v->get_attribute(v, :initialize_to_zero)
+    filterfn=v->get_attribute(v, :initialize_to_zero, false)
 )
 
     init_vars = []


### PR DESCRIPTION
Remove :mesh, :initialize_to_zero from required VariableAttributes

    :mesh is not yet used anywhere
    :initialize_to_zero now assumed default false
