### PR TITLE
Fix error message from check_parameter_sum

### DIFF
--- a/src/Parameter.jl
+++ b/src/Parameter.jl
@@ -264,7 +264,7 @@ function check_parameter_sum(parameter::VecParameter, ncells; tol=1e-3)
     sumok = true
     
     isnothing(ncells) || length(parameter.v) == ncells || 
-        (sumok = false; @error "config error: length($(parameter.name)) != ncells")
+        (sumok = false; @error "config error: length($(parameter.name)) != $ncells")
     sumpar = sum(parameter.v)
     abs(sumpar - 1.0) < tol || 
         (sumok = false; @error "config error: sum($(parameter.name)) = $sumpar != 1 +/- $(tol)")


### PR DESCRIPTION
Typo: printed "ncells" as a string, instead of the contents of the variable ncells