### PR TITLE
Improve slow startup with large reaction networks

### DIFF
--- a/src/Model.jl
+++ b/src/Model.jl
@@ -571,9 +571,14 @@ function add_arrays_data!(
     return nothing
 end
 
+struct DispatchMethodLists
+    list_initialize # not typed to avoid specializing large Tuples
+    list_do # not typed to avoid specializing large Tuples
+end
+
 """
     create_dispatch_methodlists(model::Model, modeldata::AbstractModelData, arrays_idx::Int, cellranges; kwargs) 
-        -> (;list_initialize, list_do)
+        -> DispatchMethodLists(list_initialize, list_do)
  
 Compile lists of `initialize` and `do` methods + corresponding `cellrange` for main loop [`do_deriv`](@ref).
 
@@ -605,8 +610,8 @@ function create_dispatch_methodlists(
         cellranges,
         generated_dispatch,
     )
-    
-    return (;list_initialize, list_do)
+
+    DispatchMethodLists(list_initialize, list_do)
 end
 
 


### PR DESCRIPTION
Use a container DispatchMethodLists with untyped fields instead of a NamedTuple for dispatch lists returned by create_dispatch_methodlists(), so the typed Tuple of methods is only dispatched on at the final call to dispatch_methodlist() (a generated function)

This seems to improve the time for the first call to 'do_deriv', so the startup time for generated_dispatch = true is now similar to generated_dispatch = false. Presumably it was passing around large typed Tuples or NamedTuples that was causing problems, not the `@generated dispatch_methodlist()`
NB: there is now a dynamic dispatch in do_deriv (one for each of list_initialize, list_do).