### PR TITLE
Use attributes on rate variable instead of get_rate_stoichiometry()

### DIFF
--- a/src/Reaction.jl
+++ b/src/Reaction.jl
@@ -193,18 +193,6 @@ function get_variable(
     return isempty(matchvars) ? nothing : matchvars[1]
 end
 
-"""
-    get_rate_stoichiometry(rj::PB.AbstractReaction) -> Vector[(ratevarname, process, Dict(speciesname=>stoich, ...)), ...]
-
-Optionally provide rate Variable name(s), a process name ("photolysis", "reaction", ...) and stoichiometry of reactants and products, for postprocessing of results.
-"""
-function get_rate_stoichiometry(rj::AbstractReaction)
-    rs = []
-    for m in rj.methods_do
-        append!(rs, get_rate_stoichiometry(m))
-    end
-    return rs
-end
 
 ##################################################
 # Initialization callbacks

--- a/src/ReactionMethod.jl
+++ b/src/ReactionMethod.jl
@@ -174,6 +174,17 @@ is_method_setup(@nospecialize(method::ReactionMethod)) = (method in base(method.
 is_method_initialize(@nospecialize(method::ReactionMethod)) = (method in base(method.reaction).methods_initialize)
 is_method_do(@nospecialize(method::ReactionMethod)) = (method in base(method.reaction).methods_do)
 
+"""
+    get_rate_stoichiometry(m::PB.ReactionMethod) -> Vector[(ratevarname, process, Dict(speciesname=>stoich, ...)), ...]
+
+DEPRECATED: Optionally provide rate Variable name(s), a process name ("photolysis", "reaction", ...) and stoichiometry of reactants and products, for postprocessing of results.
+
+Use attributes on rate variable instead:
+- `rate_processname::String`: a process name (eg "photolysis", "reaction", ...)
+- `rate_species::Vector{String}` names of reactant and product species
+- `rate_stoichiometry::Vector{Float64}` stoichiometry of reactant and product species
+
+"""
 get_rate_stoichiometry(@nospecialize(m::ReactionMethod)) = []
 
 ###########################################

--- a/src/VariableReaction.jl
+++ b/src/VariableReaction.jl
@@ -423,6 +423,8 @@ a Tuple of VarList_xxx <: AbstractVarList, each containing a collection of [`Var
 These are then converted (by the [`create_accessors`](@ref) method) to a corresponding
 Tuple of collections of views on Domain data arrays , which are then be passed to the [`ReactionMethod`](@ref) `methodfn`.
 
+NB: creates and uses a copy of supplied Variables including metadata, so set / modify Variable attributes *before* creating a VarList.
+
 # Implementation
 Subtypes of `AbstractVarList` should implement:
 - a constructor that takes a collection of VariableReactions

--- a/src/utils/IteratorUtils.jl
+++ b/src/utils/IteratorUtils.jl
@@ -18,7 +18,8 @@ Error if iterables it1 ... itn do not have the same length (length(t1) == length
     throw(ArgumentError(errmsg))
 @inline check_lengths_equal(it1, it2, it3, it4, it5; errmsg="lengths differ") = length(it1) == length(it2) == length(it3) == length(it4) == length(it5) || 
     throw(ArgumentError(errmsg))
-
+@inline check_lengths_equal(it1, it2, it3, it4, it5, it6; errmsg="lengths differ") = length(it1) == length(it2) == length(it3) == length(it4) == length(it5) == length(it6) || 
+    throw(ArgumentError(errmsg))
 
 """
     zipstrict(iters...; errmsg="iterables lengths differ")

--- a/test/runratestoichtests.jl
+++ b/test/runratestoichtests.jl
@@ -11,7 +11,6 @@ include("ReactionRateStoichMock.jl")
     domain = PB.get_domain(model, "ocean")   
     domain.grid = PB.Grids.UnstructuredVectorGrid(ncells=10)  
     @test PB.get_length(domain) == 10
-
     modeldata = PB.create_modeldata(model)
     PB.allocate_variables!(model, modeldata, 1)
     PB.check_ready(model, modeldata)
@@ -50,14 +49,12 @@ include("ReactionRateStoichMock.jl")
     @test maximum(deltaabserr) < 1e-13
 
     @info "stoichiometry"
-    nstoichs = 0
-    for rj in domain.reactions
-        rvs = PB.get_rate_stoichiometry(rj)
-        if !isempty(rvs)
-            @test length(rvs) == 1
-            @test rvs[1] == ("myrate", "redox", Dict("SO4::Isotope" => 1.0, "H2S::Isotope" => -1.0, "O2" => -2.0))
-            nstoichs += 1
-        end
-    end
-    @test nstoichs == 1
+    ratevars = PB.get_variables(domain, v->PB.has_attribute(v, :rate_processname))
+    @test length(ratevars) == 1
+    
+    rv = ratevars[1]
+    @test rv.name == "myrate"
+    @test PB.get_attribute(rv, :rate_processname) == "redox"
+    speciesstoich = Dict(zip(PB.get_attribute(rv, :rate_species), PB.get_attribute(rv, :rate_stoichiometry)))
+    @test speciesstoich == Dict("SO4::Isotope" => 1.0, "H2S::Isotope" => -1.0, "O2" => -2.0)      
 end


### PR DESCRIPTION
This means the reaction rate information is available when analysing output, without needing to recreate the model.

get_rate_stoichiometry(m::ReactionMethod) is now not used (not removed the method yet so existing code will still run)

New attributes on rate variable:
- `rate_processname::String`: a process name (eg "photolysis", "reaction", ...)
- `rate_species::Vector{String}` names of reactant and product species
- `rate_stoichiometry::Vector{Float64}` stoichiometry of reactant and product species