### PR TITLE
Add :gamma variable attribute for sediment solute state variable

### DIFF
--- a/src/VariableAttributes.jl
+++ b/src/VariableAttributes.jl
@@ -171,6 +171,8 @@ const StandardAttributes = [
                                           :deposition_velocity,   missing,        false,      "cm s-1",   "surface deposition velocity for atmospheric tracer")
     Attribute{Union{Float64,Missing}, Nothing}(
                                           :rainout,               missing,        false,      "",         "normalized rainout rate for atmospheric tracer")
+    Attribute{Union{Float64,Missing}, Nothing}(
+                                          :gamma,                 missing,        false,      "",         "bioirrigation scaling factor for sediment solute")
 ]
 
 

--- a/src/reactioncatalog/Reservoirs.jl
+++ b/src/reactioncatalog/Reservoirs.jl
@@ -240,7 +240,8 @@ function PB.register_methods!(rj::ReactionReservoir)
                 :vertical_movement=>0.0,
                 :specific_light_extinction=>0.0,
                 :vphase=>PB.VP_Undefined,
-                :diffusivity_speciesname=>""
+                :diffusivity_speciesname=>"",
+                :gamma=>missing,
             )
         )
     ]


### PR DESCRIPTION
Define :gamma attribute for use with sediment models (scaling factor 0-1 for solute bioirrigation)

Add to ReactionReservoir as an attribute on _conc variable, with default value 'missing'.