### PR TITLE
Updates to support PALEOaqchem generic chemistry

### DIFF
--- a/docs/src/Reaction API.md
+++ b/docs/src/Reaction API.md
@@ -74,10 +74,10 @@ AbstractVarList
 VarList_single
 VarList_namedtuple
 VarList_tuple
+VarList_ttuple
 VarList_vector
 VarList_vvector
 VarList_nothing
-VarList_tuple_nothing
 ```
 
 ### Implementing method functions

--- a/src/ReactionMethod.jl
+++ b/src/ReactionMethod.jl
@@ -128,7 +128,7 @@ call_method_codefn(io::IO, codefn, method::ReactionMethod{M, R, P, 5}, vardata, 
     
 Get all [`VariableReaction`](@ref)s from `method` as a Tuple of `Vector{VariableReaction}`
 """
-get_variables_tuple(@nospecialize(method::ReactionMethod)) = Tuple(get_variables(vl) for vl in method.varlists)
+get_variables_tuple(@nospecialize(method::ReactionMethod); flatten=true) = Tuple(get_variables(vl; flatten) for vl in method.varlists)
 
 """
     get_variables(method::AbstractReactionMethod; filterfn = v -> true) -> Vector{VariableReaction}

--- a/src/VariableDomain.jl
+++ b/src/VariableDomain.jl
@@ -361,7 +361,7 @@ end
 
 function add_dependency(vardom::VariableDomPropDep, varreact::VariableReaction{VT_ReactDependency})
     push!(vardom.var_dependencies, varreact)
-    if get_attribute(varreact, :vfunction) in (VF_StateExplicit, VF_State) 
+    if get_attribute(varreact, :vfunction) in (VF_StateExplicit, VF_StateTotal, VF_State) 
         @debug "    Resetting master variable"
         _reset_master!(vardom, varreact)
     end   
@@ -371,7 +371,7 @@ end
 function add_dependency(vardom::VariableDomContribTarget, varreact::VariableReaction{VT_ReactDependency})
     push!(vardom.var_dependencies, varreact)
     vf = get_attribute(varreact, :vfunction)
-    if vf in (VF_StateExplicit, VF_State) 
+    if vf in (VF_StateExplicit, VF_StateTotal, VF_State) 
         error("attempt to link Dependency with :vfunction==$vf to a VariableDomContribTarget "*
             "$(fullname(varreact)) --> $(fullname(vardom))")
     end   

--- a/src/reactionmethods/SetupInitializeUtilityMethods.jl
+++ b/src/reactionmethods/SetupInitializeUtilityMethods.jl
@@ -17,7 +17,7 @@ at beginning of integration.
   
 # Keywords
 - `filterfn`: set to f(var)::Bool to override the default selection for state variables only
-  (Variables with `:vfunction in (VF_StateExplicit, VF_State, VF_Total, VF_Constraint)`)
+  (Variables with `:vfunction in (VF_StateExplicit, VF_State, VF_Total, VF_StateTotal, VF_Constraint)`)
 - `force_initial_norm_value=false`: `true` to always use `:initial_value`, `:norm_value`, even for variables with `:vfunction=VF_Undefined`
 - `transfer_attribute_vars=[]`: Set to a list of the same length as `variables` to initialise `variables`
   from attributes of `transfer_attribute_vars`.
@@ -41,7 +41,7 @@ Example: To interpret `:initial_value` as a concentration-like quantity:
 """
 function add_method_setup_initialvalue_vars_default!(
     react::AbstractReaction, variables;
-    filterfn=var -> get_attribute(var, :vfunction) in (VF_StateExplicit, VF_State, VF_Total, VF_Constraint),
+    filterfn=var -> get_attribute(var, :vfunction) in (VF_StateExplicit, VF_State, VF_Total,VF_StateTotal, VF_Constraint),
     force_initial_norm_value=false,
     transfer_attribute_vars = [],
     convertvars = [],

--- a/test/configreservoirs.yaml
+++ b/test/configreservoirs.yaml
@@ -87,7 +87,9 @@ model1:
                         R:initial_value:        1.0  # concentration m-3
 
                 reservoir_conc_tracer:
-                    class: ReactionReservoirConcTotal
+                    class: ReactionReservoirTotal
+                    parameters:
+                        state_conc: true
                     variable_links:
                         R*: C*
                     variable_attributes:


### PR DESCRIPTION
- New VariableFunction VF_StateTotal to distinguish state variables associated with Total variables from state variables associated with Constraint variables (which continue to use VariableFunction VF_State). See PALEOmodel SolverView documentation for rationale.

- Update StandardAttributes list (add :totalnames, :rate_processname, :rate_species, :rate_stoichiometry, :diffusivity, :charge, remove :totalname). Add 'standard_attribute_type' function to simplify netcdf output/input.

- ReactionReservoir remove 'stateexplicit' parameter. Use new PALEOaqchem ReactionConstraintReservoir, ReactionImplicitReservoir instead.

- Remove ReactionReservoirConc, ReactionReservoirConcTotal names. This is a fix for possible name clash with work-in-progress atm chem configs, can still use ReactionReservoir, ReactionReservoirTotal with parameter 'state_conc = true'.