### PR TITLE
Define cartesian_size for all grids

### DIFF
--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -217,6 +217,10 @@ PB.internal_size(space::Type{PB.ScalarSpace}, grid::Union{PB.AbstractMesh, Nothi
 # allow Vector variables length 1 in a 0D Domain without a grid
 PB.internal_size(space::Type{PB.CellSpace}, grid::Nothing) = (1, )
 
+# allow single dimension
+PB.cartesian_size(grid::Nothing) = (1, )
+cartesian_to_internal(grid::Nothing, griddata::AbstractArray) = griddata
+
 get_subdomain(grid::Nothing, subdomainname::AbstractString) = error("get_subdomain: no subdomain $subdomainname")
 
 """
@@ -264,6 +268,10 @@ function Base.show(io::IO, grid::UnstructuredVectorGrid)
 end
 
 PB.internal_size(space::Type{PB.CellSpace}, grid::UnstructuredVectorGrid) = (grid.ncells, )
+
+# single dimension
+PB.cartesian_size(grid::UnstructuredVectorGrid) = (grid.ncells, )
+cartesian_to_internal(grid::UnstructuredVectorGrid, griddata::AbstractArray) = griddata
 
 """
     get_region(grid::UnstructuredVectorGrid, values; cell) -> 
@@ -332,6 +340,10 @@ end
 
 PB.internal_size(space::Type{PB.CellSpace}, grid::UnstructuredColumnGrid) = (grid.ncells, )
 PB.internal_size(space::Type{PB.ColumnSpace}, grid::UnstructuredColumnGrid) = (length(grid.Icolumns), )
+
+# single dimension
+PB.cartesian_size(grid::UnstructuredColumnGrid) = (grid.ncells, )
+cartesian_to_internal(grid::UnstructuredColumnGrid, griddata::AbstractArray) = griddata
 
 """
     get_region(grid::UnstructuredColumnGrid, values; column, [cell=nothing]) -> 

--- a/src/VariableReaction.jl
+++ b/src/VariableReaction.jl
@@ -583,7 +583,7 @@ get_variables(vl::VarList_tuple; flatten=true) = filter(!isnothing, vl.vars)
 create_accessors(vl::VarList_tuple, modeldata::AbstractModelData, arrays_idx::Int) =
     Tuple(isnothing(v) ? nothing : create_accessor(v, modeldata, arrays_idx, vl.components) for v in vl.vars)
 
-VarList_tuple_nothing(nvec) = VarList_tuple(fill(nothing, nvec))
+Base.@deprecate VarList_tuple_nothing(nvec) VarList_tuple(fill(nothing, nvec))
 
 """
     VarList_ttuple(varcollection) -> VarList_ttuple


### PR DESCRIPTION
Define 'cartesian_size' for all grids, including 'UnstructuredVectorGrid' and 'UnstructuredColumnGrid', returning a single dimension with length = number of cells.

This allows generic code eg in ReactionForceGrid to work for these grids, assuming the supplied forcing file has a single spatial dimension corresponding to the total number of cells in the model grid.