### PR TITLE
Add new check_variable_links method

### DIFF
--- a/docs/src/Solver API.md
+++ b/docs/src/Solver API.md
@@ -13,6 +13,7 @@ CurrentModule = PALEOboxes
 ```
 ```@docs
 create_model_from_config(config_file::AbstractString, configmodel::AbstractString)
+check_variable_links
 create_modeldata(model::Model, vectype::DataType=Array{Float64,1})
 ModelData
 add_arrays_data!

--- a/src/Domain.jl
+++ b/src/Domain.jl
@@ -241,14 +241,14 @@ end
 
 "Check configuration"
 function check_configuration(domain::Domain, model::Model)
-    configok = true
+    config_ok = true
     for react in domain.reactions
         if !check_configuration(react, model)
-            configok = false
+            config_ok = false
         end
     end
 
-    return configok
+    return config_ok
 end
 
 

--- a/test/configbase.yaml
+++ b/test/configbase.yaml
@@ -134,3 +134,20 @@ model_with_invalid_variable_attribute:
         oceanfloor:
             reactions:
 
+model_with_unlinked_variable:
+    domains:
+        ocean:
+
+            reactions:
+                julia_paleo_mock:
+                    class: ReactionPaleoMock
+                    parameters:
+                    
+                    variable_links:
+                        scalar_dep:  host_supplied_dep
+
+        oceansurface:
+            reactions:
+
+        oceanfloor:
+            reactions:

--- a/test/runbasetests.jl
+++ b/test/runbasetests.jl
@@ -136,3 +136,13 @@ end
     @test length(model.domains) == 3
 
 end
+
+@testset "PALEOboxes base unlinked variable" begin
+
+    model = PB.create_model_from_config("configbase.yaml", "model_with_unlinked_variable")
+
+    @test PB.check_variable_links(model; throw_on_error=true, expect_hostdep_varnames=["ocean.host_supplied_dep"]) == true
+    
+    @test_throws ErrorException PB.check_variable_links(model) 
+
+end


### PR DESCRIPTION
Add
    check_variable_links(model, modeldata; [throw_on_error=true] [, expect_hostdep_varnames=["global.tforce"]]) -> links_ok::Bool

This checks that all Variables are linked correctly, by checking that there are no unexpected host-dependent non-state Variables (ie unlinked Variables).

This should be called soon after 'create_model_from_config', so that an appropriate error is generated early in the user model script if any variables are unlinked.

Remove the variable link check from 'check_ready', as that was too late to be useful (often a hard-to-interpret error to do with Variable size or allocation had already happened).

See corresponding PR in PALEOmodel to add this check to PALEOmodel.initialize!