### PR TITLE
Better error message if a ReactionMethod fails at runtime

### DIFF
--- a/src/Reaction.jl
+++ b/src/Reaction.jl
@@ -324,11 +324,13 @@ end
 add_method_do!(@nospecialize(reaction::AbstractReaction), @nospecialize(methodfn::Function), @nospecialize(vars::Tuple{Vararg{AbstractVarList}}); kwargs...) = 
     _add_method!(reaction, methodfn, vars, add_method_do!; kwargs...)
 
+default_preparefn(m, vardata) = vardata
+
 function _add_method!(
     @nospecialize(reaction::AbstractReaction), @nospecialize(methodfn::Function), @nospecialize(vars::Tuple{Vararg{AbstractVarList}}), add_method_fn;
     name=string(methodfn),
     p=nothing,
-    preparefn=(m, vardata) -> vardata,
+    preparefn=default_preparefn,
     operatorID=reaction.operatorID,
     domain=reaction.domain
 )
@@ -611,15 +613,19 @@ function Base.show(io::IO, react::AbstractReaction)
 end
 
 function Base.show(io::IO, ::MIME"text/plain", react::AbstractReaction)
-    println(io, typename(react))
-    println(io, "  name='", react.name, "'")
-    println(io, "  classname='", react.classname, "'")
-    println(io, "  domain='", domainname(react), "'")
-    println(io, "  operatorID=", react.operatorID)
-    println(io, "  parameters=", get_parameters(react))
-    println(io, "  methods_setup=", react.methods_setup)
-    println(io, "  methods_initialize=", react.methods_initialize)
-    println(io, "  methods_do=", react.methods_do)
+    dump_reaction(io, react)
+end
+
+function dump_reaction(io::IO, react::AbstractReaction; prefix="", show_parameters::Bool=true)
+    println(io, prefix, typename(react))
+    println(io, prefix, "  name='", react.name, "'")
+    println(io, prefix, "  classname='", react.classname, "'")
+    println(io, prefix, "  domain='", domainname(react), "'")
+    println(io, prefix, "  operatorID=", react.operatorID)
+    show_parameters && println(io, prefix, "  parameters=", get_parameters(react))
+    println(io, prefix, "  methods_setup=", react.methods_setup)
+    println(io, prefix, "  methods_initialize=", react.methods_initialize)
+    println(io, prefix, "  methods_do=", react.methods_do)
 end
 
 """

--- a/src/ReactionMethod.jl
+++ b/src/ReactionMethod.jl
@@ -143,7 +143,7 @@ call_method_codefn(io::IO, codefn, method::ReactionMethod{M, R, P, 5}, vardata, 
 
 """
     get_variables_tuple(method::AbstractReactionMethod) -> (Vector{VariableReaction}, ...)
-    
+     println(io, typename(react))
 Get all [`VariableReaction`](@ref)s from `method` as a Tuple of `Vector{VariableReaction}`
 """
 get_variables_tuple(@nospecialize(method::ReactionMethod); flatten=true) = Tuple(get_variables(vl; flatten) for vl in method.varlists)
@@ -209,7 +209,7 @@ get_rate_stoichiometry(@nospecialize(m::ReactionMethod)) = []
 # Pretty printing
 ############################################
 
-"compact form"
+# compact form
 function Base.show(io::IO, @nospecialize(method::ReactionMethod))
     print(
         io, 
@@ -219,4 +219,17 @@ function Base.show(io::IO, @nospecialize(method::ReactionMethod))
             "', operatorID=", method.operatorID,
             ")",
     )
+end
+
+# multiline form
+function Base.show(io::IO, ::MIME"text/plain", @nospecialize(method::ReactionMethod))
+    println(io, "ReactionMethod")
+    println(io, "  fullname='", fullname(method), "'") 
+    println(io, "  methodfn=", string(method.methodfn))
+    println(io, "  preparefn=", string(method.preparefn))
+    println(io, "  domain='", method.domain.name , "'")
+    println(io, "  operatorID=", method.operatorID, "'")
+
+    print(io, "  reaction=")
+    dump_reaction(io, method.reaction; prefix="  ", show_parameters=false)
 end


### PR DESCRIPTION
Catch runtime exception if a ReactionMethod fails, and print an error message containing tje name of the failed Reaction as in the YAML config file. This is helpful if there are multiple instances of the same Reaction and it's not clear which one is failing.

NB: requires 'generated_dispatch=false' argument to PALEOmodel.initialize!