### PR TITLE
Consistency fix for grid methods with no grid

### DIFF
--- a/src/CoordsDims.jl
+++ b/src/CoordsDims.jl
@@ -50,7 +50,7 @@ PALEO convention is that where possible `coordinates` contains:
 function set_coordinates! end
 
 """
-    function get_coordinates(obj, dimname) -> coordinates::Vector{String}
+    function get_coordinates(obj, dimname) -> coordinates::Vector
 
 Get coordinates (if any) attached to `dimname` for PALEO object `obj`
 

--- a/src/Grids.jl
+++ b/src/Grids.jl
@@ -321,12 +321,12 @@ function _show_subdomains_dimensions_coordinates(io, grid::PB.AbstractMesh)
 end
 
 # generic fallback for named cells 
-substitute_cell_names(grid::PB.AbstractMesh, cells) = cells
-substitute_cell_names(grid::PB.AbstractMesh, cells::Union{Number, Symbol}) =
+substitute_cell_names(grid::PB.AbstractMeshOrNothing, cells) = cells
+substitute_cell_names(grid::PB.AbstractMeshOrNothing, cells::Union{Number, Symbol}) =
     substitute_cell_names(grid, [cells])[]
 
 # generic fallback for column indices
-function column_indices(grid::PB.AbstractMesh, column)
+function column_indices(grid::PB.AbstractMeshOrNothing, column)
     throw(ArgumentError("grid $grid does not support column selection"))
 end
 


### PR DESCRIPTION
    subsitute_cell_names
    column_indices

generic fallbacks include no grid case (grid == nothing)