### PR TITLE
Workaround for SLEEF_jll issues with Windows

### DIFF
--- a/src/utils/SIMDutils.jl
+++ b/src/utils/SIMDutils.jl
@@ -11,7 +11,6 @@ using ...PALEOboxes: @public
 @public FP64P2, FP64P4, FP32P4, FP32P8
 @public SIMDIter, vgatherind, vscatterind!, vaddind!
 
-import SLEEF_jll
 import SIMD
 import Preferences
 
@@ -281,6 +280,9 @@ const USE_SLEEF = @Preferences.load_preference("USE_SLEEF", false)
 @static if USE_SLEEF
     @info "$(@__MODULE__) defining Vectorized SIMD functions log, exp, log10 functions from Sleef library $(SLEEF_jll.libsleef)"*
         " - to disable Sleef, set USE_SLEEF = false in LocalPreferences.toml and restart your Julia session"
+    
+    import SLEEF_jll
+
     # exp Sleef Vectorized double/single precision base-e exponential functions functions with 1.0 ULP error bound
     sleefexp(v::FP64P4_d)   = ccall((:Sleef_expd4_u10, SLEEF_jll.libsleef), FP64P4_d, (FP64P4_d,), v)
     Base.exp(v::FP64P4)     = SIMD.Vec(sleefexp(v.data))


### PR DESCRIPTION
Move `import SLEEF_jll` so it only runs if optional SLEEF support set in preferences

Workaround for problems seen on Windows where the import fails with SLEEF_jll v3.7.0