### PR TITLE
Workaround for YAML.jl v0.4.13 - restrict [compat]

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -51,7 +51,7 @@ StaticArrays = "1.4"
 StructArrays = "0.6, 0.7"
 TestEnv = "1.0"
 TimerOutputs = "0.5"
-YAML = "0.4.7"
+YAML = "0.4.7 - 0.4.12"
 julia = "1.6"
 
 [extras]


### PR DESCRIPTION
Update Project.toml [compat] to restrict YAML version to
  YAML = "0.4.7 - 0.4.12"

This is a workaround for a breaking change in YAML v0.4.13 that breaks merge keys
PR with the change is: https://github.com/JuliaData/YAML.jl/pull/141
Reported as issue: https://github.com/JuliaData/YAML.jl/issues/243